### PR TITLE
Support update of root object type

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,13 @@
 {
-    "recommendations": [
-      "bilelmoussaoui.flatpak-vscode",
-      "editorconfig.editorconfig",
-      "dbaeumer.vscode-eslint",
-      "esbenp.prettier-vscode",
-      "mrorz.language-gettext",
-      "yzhang.markdown-all-in-one",
-      "mesonbuild.mesonbuild",
-      "prince781.vala"
-    ]
+  "recommendations": [
+    "bilelmoussaoui.flatpak-vscode",
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "mrorz.language-gettext",
+    "yzhang.markdown-all-in-one",
+    "mesonbuild.mesonbuild",
+    "prince781.vala",
+    "bodil.blueprint-gtk"
+  ]
 }

--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -62,18 +62,30 @@ export default function Internal({
     } else {
       obj = updateBuilderNonRoot(object_preview);
     }
-    builder.expose_object(original_id, obj);
+
+    if (original_id) {
+      builder.expose_object(original_id, obj);
+    }
+  }
+
+  function setObjectRoot(object) {
+    object_root = object;
+    object_root.set_hide_on_close(true);
+    object_root.connect("close-request", () => {
+      onWindowChange(false);
+    });
   }
 
   function updateBuilderRoot(object_preview, builder, original_id) {
     stack.set_visible_child_name("open_window");
 
     if (!object_root) {
-      object_root = object_preview;
-      object_root.set_hide_on_close(true);
-      object_root.connect("close-request", () => {
-        onWindowChange(false);
-      });
+      setObjectRoot(object_preview);
+    } else if (
+      object_root.constructor.$gtype !== object_preview.constructor.$gtype
+    ) {
+      object_root.destroy();
+      setObjectRoot(object_preview);
     } else {
       for (const prop of object_root.constructor.list_properties()) {
         if (!(prop.flags & GObject.ParamFlags.WRITABLE)) continue;

--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -1,5 +1,6 @@
 import Gtk from "gi://Gtk";
 import GObject from "gi://GObject";
+import GLib from "gi://GLib";
 
 import * as ltx from "../lib/ltx.js";
 import * as postcss from "../lib/postcss.js";
@@ -325,7 +326,7 @@ function targetBuildable(tree) {
   }
 
   const original_id = child.attrs.id;
-  const target_id = "workbench_" + Math.random().toString().substring(2);
+  const target_id = "workbench_" + GLib.uuid_string_random();
   child.attrs.id = target_id;
 
   return [target_id, tree.toString(), original_id];

--- a/src/overrides.js
+++ b/src/overrides.js
@@ -15,10 +15,13 @@ system.exit = function exit(code) {
 
 // GTypeName must be unique globally
 // there is no unregister equivalent to registerClass and
-// this is what GNOME Shell does too according to Verde
+// this is what GNOME Shell does too according to Verdre
 // https://github.com/sonnyp/Workbench/issues/50
+const types = Object.create(null);
 const _registerClass = GObject.registerClass;
 GObject.registerClass = function registerClass(klass, ...args) {
-  klass.GTypeName = klass.GTypeName + Math.random().toString().split("0.")[1];
+  const { GTypeName } = klass;
+  types[GTypeName] = (types[GTypeName] || 0) + 1;
+  klass.GTypeName = GTypeName + types[GTypeName];
   return _registerClass(klass, ...args);
 };


### PR DESCRIPTION
Fixes https://github.com/sonnyp/Workbench/issues/59

When the new UI code would change the type of the root object - simply destroy the previous one and set the new root object.

From a UX perspective

If the previous object was a GtkRoot - the window is closed
If the new object isn't a GtkRoot - the new object is directly previewed in Workbench window 
If the new object is a GTKRoot - user simply has to click on the primary button "Show Preview Window"