### PR TITLE
Prevent false positive in assertBuildable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ lint:
 	./node_modules/.bin/eslint --cache --max-warnings=0 src/
 
 test: lint
+	./src/troll/tst/bin.js test/workbench.test.js
 # https://github.com/ximion/appstream/issues/398#issuecomment-1129454985
 # flatpak run org.freedesktop.appstream.cli validate --override=release-time-missing=info --no-net data/re.sonny.Workbench.metainfo.xml
 	desktop-file-validate --no-hints data/re.sonny.Workbench.desktop

--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -169,7 +169,7 @@ export default function Previewer({
       tree = ltx.parse(text);
       ({ target_id, text, original_id, template } = targetBuildable(tree));
     } catch (err) {
-      logError(err);
+      // logError(err);
       logger.debug(err);
     }
 

--- a/src/Previewer/utils.js
+++ b/src/Previewer/utils.js
@@ -1,0 +1,38 @@
+import GObject from "gi://GObject";
+import Gtk from "gi://Gtk";
+
+export function getObjectClass(class_name) {
+  const split = class_name.split(/(?=[A-Z])/);
+  if (split.length < 2) return;
+
+  const [ns, ...rest] = split;
+  return imports.gi[ns]?.[rest.join("")];
+}
+
+// TODO: GTK Builder shouldn't crash when encountering a non buildable parent
+// https://github.com/sonnyp/Workbench/issues/49
+export function assertBuildable(el) {
+  for (const el_object of el.getChildren("object")) {
+    walkDown(el_object);
+  }
+}
+
+function walkDown(el_object) {
+  const parent = el_object.parent?.parent;
+  if (parent && parent !== el_object.root()) {
+    assertIsBuildable(parent);
+  }
+
+  for (const el_child of el_object.getChildren("child")) {
+    for (const el of el_child.getChildren("object")) {
+      walkDown(el);
+    }
+  }
+}
+
+function assertIsBuildable(element) {
+  const klass = getObjectClass(element.attrs.class);
+  if (!klass) return;
+  if (GObject.type_is_a(klass, Gtk.Buildable)) return;
+  throw new Error(`${element.attrs.class} is not a GtkBuildable`);
+}

--- a/src/Previewer/utils.js
+++ b/src/Previewer/utils.js
@@ -13,26 +13,22 @@ export function getObjectClass(class_name) {
 // https://github.com/sonnyp/Workbench/issues/49
 export function assertBuildable(el) {
   for (const el_object of el.getChildren("object")) {
-    walkDown(el_object);
+    asssertBuildableIterate(el_object);
   }
 }
 
-function walkDown(el_object) {
+function asssertBuildableIterate(el_object) {
   const parent = el_object.parent?.parent;
   if (parent && parent !== el_object.root()) {
-    assertIsBuildable(parent);
+    const klass = getObjectClass(parent.attrs.class);
+    if (!klass) return;
+    if (GObject.type_is_a(klass, Gtk.Buildable)) return;
+    throw new Error(`${parent.attrs.class} is not a GtkBuildable`);
   }
 
   for (const el_child of el_object.getChildren("child")) {
     for (const el of el_child.getChildren("object")) {
-      walkDown(el);
+      asssertBuildableIterate(el);
     }
   }
-}
-
-function assertIsBuildable(element) {
-  const klass = getObjectClass(element.attrs.class);
-  if (!klass) return;
-  if (GObject.type_is_a(klass, Gtk.Buildable)) return;
-  throw new Error(`${element.attrs.class} is not a GtkBuildable`);
 }

--- a/src/workbench.gresource.xml
+++ b/src/workbench.gresource.xml
@@ -68,6 +68,7 @@
     <file>Previewer/Internal.js</file>
     <file>Previewer/External.js</file>
     <file>Previewer/DBusPreviewer.js</file>
+    <file>Previewer/utils.js</file>
     <file>logger.js</file>
     <file>main.js</file>
     <file>overrides.js</file>

--- a/test/workbench.test.js
+++ b/test/workbench.test.js
@@ -1,0 +1,207 @@
+import "gi://Gtk?version=4.0";
+
+import tst, { assert } from "../src/troll/tst/tst.js";
+import { parse } from "../src/lib/ltx.js";
+
+import { assertBuildable } from "../src/Previewer/utils.js";
+
+const test = tst("assertBuildable");
+
+test("assertBuildable", () => {
+  assertBuildable(
+    parse(
+      `
+<interface>
+</interface>
+`.trim()
+    )
+  );
+  assertBuildable(
+    parse(
+      `
+<interface>
+  <object>
+  </object>
+</interface>
+`.trim()
+    )
+  );
+  assertBuildable(
+    parse(
+      `
+<interface>
+  <object class="Foobar">
+  </object>
+</interface>
+`.trim()
+    )
+  );
+  assertBuildable(
+    parse(
+      `
+<interface>
+  <object class="AdwLeafletPage">
+  </object>
+</interface>
+`.trim()
+    )
+  );
+  assertBuildable(
+    parse(
+      `
+<interface>
+  <object class="AdwLeafletPage">
+    <child>
+    </child>
+  </object>
+</interface>
+`.trim()
+    )
+  );
+  assert.throws(() => {
+    assertBuildable(
+      parse(
+        `
+  <interface>
+    <object class="AdwLeafletPage">
+      <child>
+        <object />
+      </child>
+    </object>
+  </interface>
+  `.trim()
+      )
+    );
+  });
+
+  // https://github.com/sonnyp/Workbench/issues/49
+  assertBuildable(
+    parse(
+      `
+<?xml version='1.0' encoding='UTF-8' ?>
+<interface>
+  <child>
+    <object class="GtkLabel">
+      <property name="label">Test</property>
+    </object>
+  </child>
+</interface>
+`.trim()
+    )
+  );
+
+  // https://github.com/sonnyp/Workbench/issues/49
+  assert.throws(() => {
+    assertBuildable(
+      parse(
+        `
+  <?xml version='1.0' encoding='UTF-8' ?>
+  <interface>
+    <object class="GtkBox">
+      <child>
+        <object class="AdwTabView"/>
+      </child>
+    </object>
+    <object class="AdwTabPage">
+      <child>
+        <object class="GtkLabel">
+          <property name="label">Hello</property>
+        </object>
+      </child>
+    </object>
+  </interface>
+  `.trim()
+      )
+    );
+  }, /AdwTabPage is not a GtkBuildable/);
+
+  // https://github.com/sonnyp/Workbench/issues/135
+  assertBuildable(
+    parse(
+      `
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="MainWindow" parent="AdwApplicationWindow">
+    <child>
+      <object class="AdwLeaflet" id="main_leaflet">
+        <property name="homogeneous">true</property>
+        <property name="can-navigate-back">true</property>
+        <property name="can-navigate-forward">true</property>
+        <property name="transition-type">over</property>
+        <signal name="notify::folded" handler="on_leaflet_folded"/>
+        <child>
+          <object class="AdwLeafletPage" id="chat_sidebar">
+            <property name="child">
+              <object class="GtkBox" id="sidebar_box">
+                <property name="hexpand">false</property>
+                <property name="vexpand">true</property>
+                <property name="orientation">horizontal</property>
+                <property name="width-request">360</property>
+                <property name="height-request">100</property>
+                <child>
+                  <object class="GtkBox" id="server_box">
+                    <property name="orientation">vertical</property>
+                    <property name="hexpand">false</property>
+                    <property name="vexpand">true</property>
+                    <property name="width-request">58</property>
+                    <child>
+                      <object class="AdwHeaderBar" id="server_header">
+                        <child type="title">
+                          <object class="ChatSidebarMenu" id="app_menu"></object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="server_scroll">
+                        <property name="hexpand">false</property>
+                        <property name="vexpand">true</property>
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="vscrollbar-policy">external</property>
+                        <child>
+                          <object class="GtkListView" id="server_list">
+                            <property name="hexpand">false</property>
+                            <property name="vexpand">true</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="channels_box">
+                    <child>
+                      <object class="AdwHeaderBar" id="channels_header"></object>
+                    </child>
+                    <child>
+                      <object class="GtkListView" id="channels_categories"></object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwLeafletPage" id="chat_content">
+            <property name="child">
+              <object class="AdwFlap" id="channel_flap">
+                <property name="flap">
+                  <object class="GtkBox" id="channel_sidebar">
+                    <property name="orientation">vertical</property>
+                  </object>
+                </property>
+              </object>
+            </property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+`.trim()
+    )
+  );
+});
+
+export default test;


### PR DESCRIPTION
This implementation is more in line with what GtkBuilder actually does which is looking at each object and asserting that the parent object implements GtkBuildable.

Fixes https://github.com/sonnyp/Workbench/issues/135

Could not use GLib.MarkupParser because of https://gitlab.gnome.org/GNOME/gjs/-/issues/448#note_1499305