### PR TITLE
Throttle Blueprint updates

### DIFF
--- a/re.sonny.Workbench.json
+++ b/re.sonny.Workbench.json
@@ -1,7 +1,7 @@
 {
   "id": "re.sonny.Workbench",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "43beta",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "workbench",
   "finish-args": [

--- a/re.sonny.Workbench.json
+++ b/re.sonny.Workbench.json
@@ -1,7 +1,7 @@
 {
   "id": "re.sonny.Workbench",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "42",
+  "runtime-version": "43beta",
   "sdk": "org.gnome.Sdk",
   "command": "workbench",
   "finish-args": [

--- a/src/util.js
+++ b/src/util.js
@@ -150,3 +150,26 @@ export function decode(data) {
   }
   return new TextDecoder().decode(data);
 }
+
+// Take a function that return a promise and returns a function
+// that will discard all calls during a pending execution
+// it's like a job queue with a max size of 1 and no concurrency
+export function unstack(fn) {
+  let latest_promise;
+  let latest_arguments;
+  let pending = false;
+
+  return function unstack_wrapper(...args) {
+    latest_arguments = args;
+
+    if (pending) return;
+
+    if (!latest_promise) latest_promise = fn(...latest_arguments);
+
+    pending = true;
+    latest_promise.finally(() => {
+      pending = false;
+      latest_promise = fn(...latest_arguments);
+    });
+  };
+}


### PR DESCRIPTION
Closes https://github.com/sonnyp/Workbench/issues/148

The current implementation (in `main`) is fairly naive; on each text update, Workbench sends the whole text to the Blueprint LSP, waits for an event and then update the Builder.

The whole thing is asynchronous, and it takes longer to complete than the time it takes to get the next "update" signal.
This PR fixes that by waiting for the latest compile before starting the next one.

Here are a couple of ideas on how to make Blueprint updates even faster but we I'll need to measure impact first

1. Extract the event to be its own routine (outside of  `compileBlueprint`) 
2. Implement LSP text range updates
3. Embed/use pyjobject 
4. Use https://github.com/Prince781/lsp-glib