### PR TITLE
Fix Vala external preview

### DIFF
--- a/src/Previewer/External.js
+++ b/src/Previewer/External.js
@@ -85,7 +85,7 @@ export default function Previewer({
 
   function updateXML({ xml, target_id, original_id }) {
     try {
-      dbus_proxy.UpdateUiSync(xml, target_id, original_id);
+      dbus_proxy.UpdateUiSync(xml, target_id, original_id || "");
     } catch (err) {
       console.debug(err);
     }

--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -378,7 +378,7 @@ function targetBuildable(tree) {
 
   const child = findPreviewable(tree);
   if (!child) {
-    return [null, ""];
+    return {};
   }
 
   const original_id = child.attrs.id;

--- a/src/Previewer/vala-previewer/previewer.vala
+++ b/src/Previewer/vala-previewer/previewer.vala
@@ -20,14 +20,16 @@ namespace Workbench {
       });
     }
 
-    public void update_ui (string content, string target_id, string original_id) {
+    public void update_ui (string content, string target_id, string original_id = "") {
       this.builder = new Gtk.Builder.from_string (content, content.length);
       var target = this.builder.get_object (target_id) as Gtk.Widget;
       if (target == null) {
         stderr.printf (@"Widget with target_id='$target_id' could not be found.\n");
           return;
       }
-      this.builder.expose_object(original_id, target);
+      if (original_id != "") {
+        this.builder.expose_object(original_id, target);
+      }
       if (target is Gtk.Root) {
         if (!(this.window.get_type () == target.get_type ())) {
           this.window.destroy ();


### PR DESCRIPTION
If there was no original id - Vala preview would fail with

> No UI definition loaded yet.

because of

> Error: Expected type string for argument 'string' but got type
undefined