### PR TITLE
Fix do not copy file source permissions

### DIFF
--- a/src/langs/vala/vala.js
+++ b/src/langs/vala/vala.js
@@ -12,7 +12,7 @@ export function setup({ data_dir, document }) {
 
   api_file.copy(
     Gio.File.new_for_path(data_dir).get_child("workbench.vala"),
-    Gio.FileCopyFlags.OVERWRITE,
+    Gio.FileCopyFlags.OVERWRITE | Gio.FileCopyFlags.TARGET_DEFAULT_PERMS,
     null,
     null,
   );


### PR DESCRIPTION
Hey,
following fix helped us to package and use Workbench on NixOS. The patch was made by [hqurve](https://github.com/hqurve) , see [original comment](https://github.com/NixOS/nixpkgs/pull/208866#issuecomment-1422462990):

> > And I think it's because the app tries to copy `$out/share/re.sonny.Workbench/workbench-api.vala` to `~/.local/share/re.sonny.Workbench/workbench.vala` on start, but files in Nix store has a 444 mode so it fails at the second run:
> 
> By searching the source for "workspace.vala", I determined that the file copy is performed at https://github.com/sonnyp/Workbench/blob/v43.3/src/langs/vala/vala.js#L13. By looking at the [GIO api for the copy function](https://developer-old.gnome.org/gio/stable/GFile.html#g-file-copy), we can use the [G_FILE_COPY_TARGET_DEFAULT_PERMS flag](https://developer-old.gnome.org/gio/stable/GFile.html#GFileCopyFlags) to "Leave target file with default perms, instead of setting the source file perms."
> 
> I applied the following patch and rebuilt workbench. After clearing the ~/.local/share/re.sonnyp.Workbench directory, reopening worked
> 
> ```
> From b5862ec862a1e9a4b01b09f3ca341e57999353c3 Mon Sep 17 00:00:00 2001
> From: hqurve <hqurve@outlook.com>
> Date: Wed, 8 Feb 2023 07:31:04 -0400
> Subject: [PATCH] do not copy source perms
> 
> ---
>  src/langs/vala/vala.js | 2 +-
>  1 file changed, 1 insertion(+), 1 deletion(-)
> 
> diff --git a/src/langs/vala/vala.js b/src/langs/vala/vala.js
> index e5ccfcc..dc0b25b 100644
> --- a/src/langs/vala/vala.js
> +++ b/src/langs/vala/vala.js
> @@ -12,7 +12,7 @@ export function setup({ data_dir, document }) {
>  
>    api_file.copy(
>      Gio.File.new_for_path(data_dir).get_child("workbench.vala"),
> -    Gio.FileCopyFlags.OVERWRITE,
> +    Gio.FileCopyFlags.OVERWRITE | Gio.FileCopyFlags.TARGET_DEFAULT_PERMS,
>      null,
>      null,
>    );
> -- 
> 2.39.1
> ```
> 
> I assume that flags work using bits. Also, you probably want to reword the commit message.
> 
> Also, by searching the code for `copy(`, I think this is the only instance of copying files

This patch propably doesn't affect any other users of Workbench but would help us to solve this issue on NixOS.

Best regards
Jonas