### PR TITLE
Simplify Library contrbutions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 Thank you for considering contributing to Workbench. Feel free to [get in touch](https://matrix.to/#/%23workbench:gnome.org).
 
-
 ## Development
 
 ### Setup
@@ -31,12 +30,11 @@ Here is a compilation of resources to learn more about the GNOME platform.
 
 * [Workbench](https://github.com/sonnyp/Workbench) 😉
 * [GObject](https://gjs.guide/guides/gobject/basics.html#gobject-construction)
-* [Asynchronous programming](https://gjs.guide/guides/gjs/asynchronous-programming.html#the-main-loop)
 * [GTK4 + GJS Book](https://rmnvgr.gitlab.io/gtk4-gjs-book/)
+* [Asynchronous programming](https://gjs.guide/guides/gjs/asynchronous-programming.html#the-main-loop)
 * [API references](https://gjs-docs.gnome.org/) make sure to enable at least GTK, GJS, GLib, Gio
 * [GJS docs](https://gitlab.gnome.org/GNOME/gjs/-/tree/master/doc)
 * [GJS examples](https://gitlab.gnome.org/GNOME/gjs/-/tree/master/examples)
-
 
 ### Library
 
@@ -46,23 +44,17 @@ Library examples and demos have 3 functions
 2. Teach how to use the APIs, patterns and widgets
 3. Provide functional snippets ready to use
 
-Keep them concise and interactive. They should have links to learn more about the topics covered.
-
 The easiest way to get started is to write an entry within Workbench directly.
 
-You can find ideas in [this issue](https://github.com/sonnyp/Workbench/issues/69). Start with something small and accessible.
+Keep them concise and interactive. They should have links to learn more about the topics covered. Make sure to follow the patterns of similar/existing entries.
 
-Once you're satisfied with the result - you can add the entry to Workbench source code and send a pull request to make it available to everyone.
+* [Check here for ideas](https://github.com/sonnyp/Workbench/issues/69)
+* Start with something small and accessible
+* Make sure to select "Blueprint" instead of "XML" in the UI panel
 
-To do so
+Once you're satisfied with the result - you can send a pull request to include it in Workbench. All you need to do is add the files to [`src/Library`](./src/Library).
 
-1. add the files in [`src/Library`](./src/Library)
-2. the paths to [`src/app.gresource.xml`](./src/app.gresource.xml)
-3. the `main.blp` path to the `blueprints` target in [`src/meson.build](./src/meson.build).
-
-If you're struggling - search the code base for an existing entry name (for example `WebSocket client`) and do the same thing for yours.
-
-Make sure it's working by running Workbench and launching your entry via the Library. If not - double check what you did and compare with other Library entries.
+Make sure it's working by rebuilding Workbench and launching your entry via the Library. If not - double check what you did and compare with other Library entries.
 
 ## Debugging
 

--- a/build-aux/list-demo-blp-files.sh
+++ b/build-aux/list-demo-blp-files.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd $MESON_SOURCE_ROOT/src || exit
+find . -path './Library/demos/*' -name '*.blp'

--- a/src/app.gresource.xml
+++ b/src/app.gresource.xml
@@ -4,41 +4,5 @@
     <file>style.css</file>
     <file>language-specs/blueprint.lang</file>
     <file>icon-development-kit.json</file>
-    <file>Library/demos/Notifications/main.js</file>
-    <file>Library/demos/Notifications/main.json</file>
-    <file>Library/demos/Notifications/main.blp</file>
-    <file>Library/demos/Notifications/main.ui</file>
-    <file>Library/demos/Notifications/main.vala</file>
-    <file>Library/demos/Platform Tools/main.blp</file>
-    <file>Library/demos/Platform Tools/main.json</file>
-    <file>Library/demos/Platform Tools/main.ui</file>
-    <file>Library/demos/HTTP Image/main.js</file>
-    <file>Library/demos/HTTP Image/main.json</file>
-    <file>Library/demos/Toasts/main.js</file>
-    <file>Library/demos/Toasts/main.json</file>
-    <file>Library/demos/Toasts/main.blp</file>
-    <file>Library/demos/Toasts/main.ui</file>
-    <file>Library/demos/Toasts/main.vala</file>
-    <file>Library/demos/WebSocket Client/main.js</file>
-    <file>Library/demos/WebSocket Client/main.json</file>
-    <file>Library/demos/WebSocket Client/main.blp</file>
-    <file>Library/demos/WebSocket Client/main.ui</file>
-    <file>Library/demos/WebSocket Client/main.vala</file>
-    <file>Library/demos/Welcome/main.css</file>
-    <file>Library/demos/Welcome/main.js</file>
-    <file>Library/demos/Welcome/main.json</file>
-    <file>Library/demos/Welcome/main.blp</file>
-    <file>Library/demos/Welcome/main.ui</file>
-    <file>Library/demos/Welcome/main.vala</file>
-    <file>Library/demos/Window/main.json</file>
-    <file>Library/demos/Window/main.blp</file>
-    <file>Library/demos/Window/main.ui</file>
-    <file>Library/demos/Custom Widget/main.blp</file>
-    <file>Library/demos/Custom Widget/main.ui</file>
-    <file>Library/demos/Custom Widget/main.js</file>
-    <file>Library/demos/Custom Widget/main.json</file>
-     <file>Library/demos/Switch/main.json</file>
-    <file>Library/demos/Switch/main.js</file>
-    <file>Library/demos/Switch/main.blp</file>
   </gresource>
 </gresources>

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,21 +11,21 @@ bin_conf.set('sourcedir', meson.source_root())
 blueprint_compiler = find_program(
   # Flatpak
   '/app/bin/blueprint-compiler',
-  # host
+  # local
   '../blueprint-compiler/blueprint-compiler.py'
 )
 
-blueprints = custom_target('blueprints',
-  input: files(
-    'Library/demos/Toasts/main.blp',
-    'Library/demos/WebSocket Client/main.blp',
-    'Library/demos/Welcome/main.blp',
-    'Library/demos/Window/main.blp',
-    'Library/demos/Custom Widget/main.blp',
-    'Library/demos/Notifications/main.blp',
-    'Library/demos/Platform Tools/main.blp',
-  ),
+install_subdir('Library/demos', install_dir : join_paths(pkgdatadir, 'Library'))
+
+output = run_command('../build-aux/list-demo-blp-files.sh', check: true)
+blueprint_files = output.stdout().strip().split('\n')
+message('blueprint files: @0@'.format(blueprint_files))
+
+custom_target('blueprints',
+  input: blueprint_files,
   output: '.',
+  install: true,
+  install_dir: pkgdatadir,
   command: [
     blueprint_compiler,
     'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'
@@ -34,7 +34,6 @@ blueprints = custom_target('blueprints',
 
 gnome.compile_resources(app_id,
   'app.gresource.xml',
-  dependencies: blueprints,
   gresource_bundle: true,
   install: true,
   install_dir: pkgdatadir,


### PR DESCRIPTION
With this change, it's only needed to add the files to `src/Library/demos`.

Fiddling with gresource, meson, ... is error prone and not very begineer friendly.

We are now loading the demo files from disk instead of from a gresource. It will be fine for now but we can optimize later when we have many entries.