### PR TITLE
Improve crash prevention

### DIFF
--- a/data/app.gschema.xml
+++ b/data/app.gschema.xml
@@ -31,5 +31,11 @@
     <key name="preview-align" type="i">
       <default>0</default>
     </key>
+    <key name="auto-preview" type="b">
+      <default>true</default>
+    </key>
+    <key name="safe-mode" type="b">
+      <default>false</default>
+    </key>
   </schema>
 </schemalist>

--- a/src/Library/demos/Welcome/main.blp
+++ b/src/Library/demos/Welcome/main.blp
@@ -41,7 +41,7 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Edit Style or UI to reload the Preview";
+        label: "Edit Style or UI to update the Preview";
       }
     }
 

--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -12,7 +12,7 @@ import Internal from "./Internal.js";
 import External from "./External.js";
 import { getClassNameType } from "../overrides.js";
 
-import { isBuilderable, isPreviewable } from "./utils.js";
+import { assertBuildable, detectCrash, isPreviewable } from "./utils.js";
 
 /*
   Always default to in-process preview
@@ -102,10 +102,12 @@ export default function Previewer({
   function start() {
     stop();
     if (handler_id_ui === null) {
-      handler_id_ui = panel_ui.connect("updated", schedule_update);
+      handler_id_ui = panel_ui.connect("updated", () => schedule_update());
     }
     if (handler_id_css === null) {
-      handler_id_css = code_view_css.connect("changed", schedule_update);
+      handler_id_css = code_view_css.connect("changed", () =>
+        schedule_update(),
+      );
     }
   }
 
@@ -114,7 +116,6 @@ export default function Previewer({
       panel_ui.disconnect(handler_id_ui);
       handler_id_ui = null;
     }
-
     if (handler_id_css) {
       code_view_css.disconnect(handler_id_css);
       handler_id_css = null;
@@ -145,8 +146,12 @@ export default function Previewer({
     },
   );
 
+  settings.connect("changed", () => {
+    if (settings.get_boolean("auto-preview")) schedule_update();
+  });
   let symbols = null;
-  async function update() {
+  async function update(force = false) {
+    if (!(force || settings.get_boolean("auto-preview"))) return;
     let text = panel_ui.xml.trim();
     let target_id;
     let tree;
@@ -167,9 +172,18 @@ export default function Previewer({
 
     if (!target_id) return;
 
-    // console.time("builderable");
-    if (!(await isBuilderable(text))) return;
-    // console.timeEnd("builderable");
+    try {
+      assertBuildable(tree);
+    } catch (err) {
+      console.warn(err.message);
+      return;
+    }
+
+    if (settings.get_boolean("safe-mode")) {
+      // console.time("detectCrash");
+      if (await detectCrash(text, target_id)) return;
+      // console.timeEnd("detectCrash");
+    }
 
     const builder = new Gtk.Builder();
     const scope = new BuilderScope();
@@ -214,16 +228,18 @@ export default function Previewer({
   const schedule_update = unstack(update, logError);
 
   async function useExternal() {
-    if (current === external) return;
-    await setPreviewer(external);
+    if (current !== external) {
+      await setPreviewer(external);
+    }
     stack.set_visible_child_name("close_window");
-    await update();
+    await update(true);
   }
 
   async function useInternal() {
-    if (current === internal) return;
-    await setPreviewer(internal);
-    await update();
+    if (current !== internal) {
+      await setPreviewer(internal);
+    }
+    await update(true);
   }
 
   async function setPreviewer(previewer) {

--- a/src/Previewer/crasher.vala
+++ b/src/Previewer/crasher.vala
@@ -2,9 +2,13 @@ public void main (string[] args) {
 	  Adw.init ();
 
     var builder = new Gtk.Builder();
+    var output = new Gtk.Window ();
 
 	  try {
 	    builder.add_from_string(args[1], -1);
+      var object = builder.get_object(args[2]) as Gtk.Widget;
+      output.set_child(object);
+
     // We are only interested in crashes here
     // Previewer.js will handle errors
 	  } catch {}

--- a/src/Previewer/utils.js
+++ b/src/Previewer/utils.js
@@ -1,6 +1,7 @@
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";
+import Adw from "gi://Adw";
 
 Gio._promisify(
   Gio.Subprocess.prototype,
@@ -26,9 +27,98 @@ export function isPreviewable(class_name) {
   return GObject.type_is_a(klass, Gtk.Widget);
 }
 
-export async function isBuilderable(str) {
-  const flags =
-    Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE;
-  const proc = Gio.Subprocess.new(["workbench-crasher", str], flags);
-  return proc.wait_check_async(null);
+export function assertBuildable(el) {
+  for (const el_object of el.getChildren("object")) {
+    assertObjectBuildable(el_object, true);
+  }
+}
+
+function getChildProperty(el) {
+  const property = getProperty(el, "child");
+  return property?.getChild("object") || null;
+}
+
+function getProperty(el, name) {
+  const properties = el.getChildren("property");
+  return properties.find((el) => el.attrs.name === name);
+}
+
+function getKlass(el) {
+  const class_name = el.attrs.class;
+  if (!class_name) return null;
+  return getObjectClass(class_name);
+}
+
+function assertObjectBuildable(el_object, root) {
+  const klass = getKlass(el_object);
+  if (klass) {
+    // GLib-GObject-ERROR: cannot create instance of abstract (non-instantiatable) type 'GtkWidget'
+    if (GObject.type_test_flags(klass, GObject.TypeFlags.ABSTRACT)) {
+      throw new Error(
+        `${klass.$gtype.name} is an abstract type. It cannot be instantiated.`,
+      );
+    }
+
+    // Gtk:ERROR:../gtk/gtkbuilder.c:1044:_gtk_builder_add: assertion failed: (GTK_IS_BUILDABLE (parent))
+    if (!GObject.type_is_a(klass, Gtk.Buildable)) {
+      if (el_object.getChildren("child").length > 0) {
+        throw new Error(
+          `${klass.$gtype.name} is not a GtkBuildable. It cannot have children`,
+        );
+      }
+    }
+
+    // Gtk:ERROR:../gtk/gtkwidget.c:2448:gtk_widget_root: assertion failed: (priv->root == NULL)
+    if (!root && GObject.type_is_a(klass, Gtk.Root)) {
+      throw new Error(
+        `${klass.$gtype.name} is a GtkRoot. GtkRoot objects can only appear at the top-level.`,
+      );
+    }
+
+    // Adwaita-gtk_window_set_titlebar() is not supported for AdwWindow
+    if (
+      GObject.type_is_a(klass, Adw.Window) &&
+      getProperty(el_object, "titlebar")
+    ) {
+      throw new Error(
+        `${klass.$gtype.name} does not support the titlebar property.`,
+      );
+    }
+
+    // Adwaita-gtk_window_set_child() is not supported for AdwWindow
+    if (
+      GObject.type_is_a(klass, Adw.Window) &&
+      getProperty(el_object, "child")
+    ) {
+      throw new Error(
+        `${klass.$gtype.name} does not support the child property.`,
+      );
+    }
+  }
+
+  // Gtk-ERROR **: 23:19:54.204: GtkStackPage '<unnamed>' [0x55b094802eb0] is missing a child widget
+  const child_property = getChildProperty(el_object);
+  if (child_property) {
+    const child_klass = getKlass(child_property);
+    if (!GObject.type_is_a(child_klass, Gtk.Widget)) {
+      throw new Error(`${child_klass.$gtype.name} is not a GtkWidget.`);
+    }
+    assertObjectBuildable(child_property, false);
+  }
+
+  for (const el_child of el_object.getChildren("child")) {
+    for (const el of el_child.getChildren("object")) {
+      assertObjectBuildable(el, false);
+    }
+  }
+}
+
+export async function detectCrash(str, object_id) {
+  // const flags =
+  //   Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE;
+  const flags = Gio.SubprocessFlags.NONE;
+  const proc = Gio.Subprocess.new(["workbench-crasher", str, object_id], flags);
+
+  const success = await proc.wait_check_async(null).catch((_err) => false);
+  return !success;
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -135,6 +135,8 @@ export default function Actions({ application }) {
   application.add_action(action_platform_tools);
 
   application.add_action(settings.create_action("color-scheme"));
+  application.add_action(settings.create_action("safe-mode"));
+  application.add_action(settings.create_action("auto-preview"));
 }
 
 const lang_filters = languages.map((language) => {

--- a/src/window.blp
+++ b/src/window.blp
@@ -100,6 +100,18 @@ Gtk.ApplicationWindow window {
       icon-name: "open-menu-symbolic";
       primary: true;
     }
+
+    [end]
+    Button button_run {
+      child: Adw.ButtonContent {
+        icon-name: "media-playback-start-symbolic";
+        label: _("_Run");
+        use-underline: true;
+      };
+      action-name: "win.run";
+      tooltip-text: _("Run (Ctrl+⏎)");
+      styles ["suggested-action"]
+    }
   };
 
   [content]
@@ -145,18 +157,6 @@ Gtk.ApplicationWindow window {
                 };
                 tooltip-text: _("Switch document");
               }
-            }
-
-            [end]
-            Button button_run {
-              child: Adw.ButtonContent {
-                icon-name: "media-playback-start-symbolic";
-                label: _("_Run");
-                use-underline: true;
-              };
-              action-name: "win.run";
-              tooltip-text: _("Run (Ctrl+⏎)");
-              styles ["suggested-action"]
             }
           }
 
@@ -266,10 +266,12 @@ Gtk.ApplicationWindow window {
             styles ["toolbar", "panel_header"]
 
             [start]
-            Label {
-              label: _("<b>Preview</b>");
-              use-markup: true;
-              styles ["dim-label"]
+            MenuButton {
+              halign: center;
+              valign: center;
+              label: _("Preview");
+              styles ["flat"]
+              menu-model: preview_menu;
             }
 
             [center]
@@ -554,4 +556,13 @@ menu menu_app {
       action: "app.about";
     }
   }
+}
+
+menu preview_menu {
+  // FIXME: It's unclear if this is needed or helpful
+  // know issue: if auto-preview is disabled, Workbench shows a blank preview on start
+  item (_("Auto-Update"), "app.auto-preview")
+  // FIXME: This will probably be removed in favor of
+  // automatcally enabling when we detect a crash
+  item (_("Safe Mode"), "app.safe-mode")
 }

--- a/src/window.js
+++ b/src/window.js
@@ -250,7 +250,7 @@ export default function Window({ application }) {
       }
 
       if (language === "JavaScript") {
-        await previewer.update();
+        await previewer.update(true);
 
         // We have to create a new file each time
         // because gjs doesn't appear to use etag for module caching
@@ -271,7 +271,7 @@ export default function Window({ application }) {
         try {
           exports = await import(`file://${file_javascript.get_path()}`);
         } catch (err) {
-          await previewer.update();
+          await previewer.update(true);
           throw err;
         } finally {
           promiseTask(
@@ -317,10 +317,7 @@ export default function Window({ application }) {
     name: "run",
   });
   action_run.connect("activate", () => {
-    // Ensure code does not run if panel is not visible
-    if (panel_code.panel.visible) {
-      runCode().catch(logError);
-    }
+    runCode().catch(logError);
   });
   window.add_action(action_run);
   application.set_accels_for_action("win.run", ["<Control>Return"]);
@@ -400,7 +397,7 @@ export default function Window({ application }) {
       panel_ui.start();
       await panel_ui.update();
       previewer.start();
-      await previewer.update();
+      await previewer.update(true);
     }
 
     documents.forEach((document) => {


### PR DESCRIPTION
Fixes https://github.com/sonnyp/Workbench/issues/215
Partially relates to https://github.com/sonnyp/Workbench/issues/218

We have a process that check if the preview is going to crash but

1. It does not prevent every possible crash
2. It makes editing slower
3. It does not provide good feedback to users
4. At least on Fedora it triggers an abrt report on every crash

This PR adds a few safeguards to return before hitting known crashes.

In addition, the process has been disabled by default under "Safe Mode" to make updates faster.
A "Auto-Update" setting was enabled as well for the preview and is enabled by default.

I don't know yet if "Safe Mode" and "Auto-Update" modes will remain.