### PR TITLE
Library: don't ignore errors from missing "main.json" files

### DIFF
--- a/src/Library/Library.js
+++ b/src/Library/Library.js
@@ -101,7 +101,7 @@ function readDemoFile(demo_name, file_name) {
   try {
     str = decode(file.load_contents(null)[1]);
   } catch (err) {
-    if (err.code !== Gio.IOErrorEnum.NOT_FOUND) {
+    if (err.code !== Gio.IOErrorEnum.NOT_FOUND && file_name !== "main.json") {
       throw err;
     }
     str = "";


### PR DESCRIPTION
When loading files for a demo some missing files ignored because they're optional, but the `main.json` file is not.

Throw an error if `Gio.IOErrorEnum.NOT_FOUND` is hit in that particular case.