### PR TITLE
Switch to jwestman/blueprint-compiler repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "troll"]
 	path = troll
 	url = https://github.com/sonnyp/troll.git
-[submodule "src/blueprint-compiler"]
+[submodule "blueprint-compiler"]
 	path = blueprint-compiler
-	url = https://gitlab.gnome.org/sonny/blueprint-compiler.git
+	url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
 [submodule "icon-development-kit-www"]
 	path = icon-development-kit-www
 	url = https://gitlab.gnome.org/Teams/Design/icon-development-kit-www.git


### PR DESCRIPTION
The `.gitmodules` file was pointing at https://gitlab.gnome.org/sonny/blueprint-compiler/, which doesn't contain the referenced commit.

Fixes #246 