### PR TITLE
Improve tooltips

### DIFF
--- a/src/Library/demos/Text Fields/main.blp
+++ b/src/Library/demos/Text Fields/main.blp
@@ -90,9 +90,9 @@ Adw.Clamp {
         Entry entry_icon {
           primary-icon-name: "about-symbolic";
           primary-icon-activatable: true;
-          primary-icon-tooltip-text: "Click on me";
+          primary-icon-tooltip-text: "Click on Me";
           secondary-icon-name: "bell-symbolic";
-          secondary-icon-tooltip-text: "No click on me";
+          secondary-icon-tooltip-text: "No Click on Me";
         }
       }
 
@@ -108,7 +108,7 @@ Adw.Clamp {
           Entry entry_progress {
             progress-fraction: 0;
             primary-icon-name: "media-playback-start-symbolic";
-            primary-icon-tooltip-text: "Play animation";
+            primary-icon-tooltip-text: "Play Animation";
           }
         }
       }

--- a/src/about.js
+++ b/src/about.js
@@ -57,6 +57,7 @@ ${getBlueprintVersion()}
     "Sriyansh Shivam https://linktr.ee/sonic_here",
     "Angelo Verlain https://www.vixalien.com",
     "bazylevnik0 https://github.com/bazylevnik0",
+    "Felipe Kinoshita https://mastodon.social/@fkinoshita",
     // Add yourself as
     // "John Doe",
     // or

--- a/src/window.blp
+++ b/src/window.blp
@@ -155,7 +155,7 @@ Gtk.ApplicationWindow window {
                     "Vala",
                   ]
                 };
-                tooltip-text: _("Switch document");
+                tooltip-text: _("Switch Document");
               }
             }
           }
@@ -229,11 +229,11 @@ Gtk.ApplicationWindow window {
                     "Blueprint",
                   ]
                 };
-                tooltip-text: _("Convert and switch syntax");
+                tooltip-text: _("Convert and Switch Syntax");
               }
               Button button_ui_experimental_blueprint {
                 icon-name: "applications-science-symbolic";
-                tooltip-text: _("Information about Blueprint");
+                tooltip-text: _("Information About Blueprint");
               }
             }
           }
@@ -283,7 +283,7 @@ Gtk.ApplicationWindow window {
                   _("Center"),
                 ]
               };
-              tooltip-text: _("Select Preview mode");
+              tooltip-text: _("Select Preview Mode");
             }
 
             [end]
@@ -388,7 +388,7 @@ Gtk.ApplicationWindow window {
                 use-underline: true;
               };
               action-name: "win.console";
-              tooltip-text: _("Show logs (Ctrl+Shift+K)");
+              tooltip-text: _("Show Logs (Ctrl+Shift+K)");
             }
 
             Button button_inspector {
@@ -412,7 +412,7 @@ Gtk.ApplicationWindow window {
                 use-underline: true;
               };
               action-name: "win.clear";
-              tooltip-text: _("Clear console (Ctrl+K)");
+              tooltip-text: _("Clear Console (Ctrl+K)");
             }
           }
         }

--- a/src/window.blp
+++ b/src/window.blp
@@ -98,6 +98,7 @@ Gtk.ApplicationWindow window {
     MenuButton button_menu {
       menu-model: menu_app;
       icon-name: "open-menu-symbolic";
+      tooltip-text: _("Main Menu");
       primary: true;
     }
 


### PR DESCRIPTION
Following what the GNOME HIG recommends I made some changes:
- Remove keyboard shortcut from tooltips, it's currently not recommended to put them there
- Make all tooltips use header capitalization
- Add a tooltip to the main menu