### PR TITLE
Improve preview screenshot

### DIFF
--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -3,11 +3,6 @@ import GObject from "gi://GObject";
 import GLib from "gi://GLib";
 import Gio from "gi://Gio";
 
-import Xdp from "gi://Xdp";
-import XdpGtk from "gi://XdpGtk4";
-
-import { portal } from "../util.js";
-
 import * as xml from "../langs/xml/xml.js";
 import * as postcss from "../lib/postcss.js";
 
@@ -291,31 +286,8 @@ export default function Previewer({
   }
 
   builder.get_object("button_screenshot").connect("clicked", () => {
-    screenshot().catch(logError);
+    screenshot({ application, window, data_dir, current }).catch(logError);
   });
-  async function screenshot() {
-    const path = GLib.build_filenamev([data_dir, "Workbench screenshot.png"]);
-
-    const success = await current.screenshot({ window, path });
-    if (!success) return;
-
-    const parent = XdpGtk.parent_new_gtk(window);
-
-    try {
-      await portal.open_uri(
-        parent,
-        `file://${path}`,
-        Xdp.OpenUriFlags.NONE, // flags
-        null, // cancellable
-      );
-    } catch (err) {
-      if (err.code !== Gio.IOErrorEnum.CANCELLED) {
-        logError(err);
-      } else {
-        throw err;
-      }
-    }
-  }
 
   setPreviewer(internal);
   start();
@@ -488,4 +460,37 @@ function makeWorkbenchTargetId() {
 }
 function isWorkbenchTargetId(id) {
   return id.startsWith(target_id_prefix);
+}
+
+async function screenshot({ application, window, data_dir, current }) {
+  const date = new GLib.DateTime().format("%Y-%m-%d %H-%M-%S");
+  // FIXME: GJS does not have Gio.File.new_build_filename
+  const file = Gio.File.new_for_path(
+    GLib.build_filenamev([
+      data_dir,
+      "screenshots",
+      `Workbench Screenshot from ${date}.png`,
+    ]),
+  );
+
+  try {
+    file.get_parent().make_directory_with_parents(null);
+  } catch (err) {
+    if (err.code !== Gio.IOErrorEnum.EXISTS) throw err;
+  }
+
+  const success = await current.screenshot({ window, path: file.get_path() });
+  if (!success) return;
+
+  const notification = new Gio.Notification();
+  const action = Gio.Action.print_detailed_name(
+    "app.show-screenshot",
+    new GLib.Variant("s", file.get_uri()),
+  );
+  notification.set_icon(new Gio.ThemedIcon({ name: "re.sonny.Workbench" }));
+  notification.set_title("Workbench");
+  notification.set_body(_("Screenshot of preview captured"));
+  notification.set_default_action(action);
+  notification.add_button(_("Show in Files"), action);
+  application.send_notification(null, notification);
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -47,27 +47,7 @@ export default function Actions({ application }) {
     parameter_type: null,
   });
   action_open_file.connect("activate", () => {
-    const parent = XdpGtk.parent_new_gtk(application.get_active_window());
-    portal.open_file(
-      parent,
-      _("Import File"),
-      filters,
-      null, // current_filter
-      null, // choices
-      Xdp.OpenFileFlags.NONE,
-      null, // cancellable,
-      (_self, res) => {
-        let uri;
-        try {
-          const results = portal.open_file_finish(res);
-          [uri] = results.recursiveUnpack().uris;
-        } catch {
-          return;
-        }
-
-        application.open([Gio.File.new_for_uri(uri)], "open");
-      },
-    );
+    openFile({ application }).catch(logError);
   });
   application.add_action(action_open_file);
   application.set_accels_for_action("app.open", ["<Control>O"]);
@@ -137,6 +117,16 @@ export default function Actions({ application }) {
   application.add_action(settings.create_action("color-scheme"));
   application.add_action(settings.create_action("safe-mode"));
   application.add_action(settings.create_action("auto-preview"));
+
+  const action_show_screenshot = new Gio.SimpleAction({
+    name: "show-screenshot",
+    parameter_type: new GLib.VariantType("s"),
+  });
+  action_show_screenshot.connect("activate", (_self, target) => {
+    const uri = target.unpack();
+    showScreenshot({ application, uri }).catch(logError);
+  });
+  application.add_action(action_show_screenshot);
 }
 
 const lang_filters = languages.map((language) => {
@@ -149,3 +139,36 @@ const filters = new GLib.Variant("a(sa(us))", [
   [_("All supported"), lang_filters.flatMap(([, types]) => types)],
   ...lang_filters,
 ]);
+
+async function openFile({ application }) {
+  const parent = XdpGtk.parent_new_gtk(application.get_active_window());
+
+  let uri;
+
+  try {
+    const results = await portal.open_file(
+      parent,
+      _("Import File"),
+      filters,
+      null, // current_filter
+      null, // choices
+      Xdp.OpenFileFlags.NONE,
+      null, // cancellable
+    );
+    [uri] = results.recursiveUnpack().uris;
+  } catch (err) {
+    if (err.code !== Gio.IOErrorEnum.CANCELLED) throw err;
+  }
+
+  application.open([Gio.File.new_for_uri(uri)], "open");
+}
+
+async function showScreenshot({ application, uri }) {
+  const parent = XdpGtk.parent_new_gtk(application.get_active_window());
+  await portal.open_directory(
+    parent,
+    uri,
+    Xdp.OpenUriFlags.NONE,
+    null, // cancellable
+  );
+}

--- a/src/init.js
+++ b/src/init.js
@@ -9,7 +9,8 @@ import Gio from "gi://Gio";
 import Xdp from "gi://Xdp";
 import Source from "gi://GtkSource";
 
-Gio._promisify(Xdp.Portal.prototype, "open_uri", "open_uri_finish");
+Gio._promisify(Xdp.Portal.prototype, "open_file", "open_file_finish");
+Gio._promisify(Xdp.Portal.prototype, "open_directory", "open_directory_finish");
 
 Gio._promisify(
   Gio.InputStream.prototype,

--- a/src/window.blp
+++ b/src/window.blp
@@ -290,9 +290,9 @@ Gtk.ApplicationWindow window {
             [end]
             Button button_screenshot {
               icon-name: "re.sonny.Workbench-screenshot-symbolic";
-              tooltip-text: _("Take Screenshot of Preview");
+              tooltip-text: _("Screenshot Preview");
               accessibility {
-                label: _("Take Screenshot of Preview");
+                label: _("Screenshot Preview");
               }
             }
           }


### PR DESCRIPTION
Follow up of https://github.com/sonnyp/Workbench/pull/274

- [x] Don't overwrite previous screenshot
- [x] Use the same date format as GNOME Shell
- [x] Save screenshots in a dedicated directory
- [x] Use open_directory instead of open_file
- [x] Check why screenshot of "View Switcher" does not work (JS) (only on modal window)
- [ ] https://github.com/sonnyp/Workbench/issues/298
- [ ] Make sure internal and external preview the same thing