### PR TITLE
feat: add an internal GI library for Workbench

### DIFF
--- a/src/about.js
+++ b/src/about.js
@@ -42,6 +42,7 @@ ${getBlueprintVersion()}
     developers: [
       "Sonny Piers https://sonny.re",
       "Lorenz Wildberg https://gitlab.gnome.org/lwildberg",
+      "Andy Holmes https://gitlab.gnome.org/andyholmes",
     ],
     designers: [
       "Sonny Piers https://sonny.re",

--- a/src/libworkbench/meson.build
+++ b/src/libworkbench/meson.build
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-FileCopyrightText: Workbench Contributors
+# SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+includedir = join_paths(prefix, get_option('includedir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
+girdir = join_paths(datadir, 'gir-1.0')
+typelibdir = join_paths(libdir, 'girepository-1.0')
+vapidir = join_paths(datadir, 'vala', 'vapi')
+
+libworkbench_api_version = '0'
+libworkbench_api_name = 'libworkbench-@0@'.format(libworkbench_api_version)
+
+
+#
+# Shared Library
+#
+libworkbench_c_args = [
+  '-Wall',
+  '-Wextra',
+  '-Wfloat-equal',
+  '-Wformat=2',
+  '-Wincompatible-pointer-types',
+  '-Wint-conversion',
+  '-Wint-to-pointer-cast',
+  '-Wmissing-include-dirs',
+  '-Woverflow',
+  '-Wpointer-arith',
+  '-Wpointer-to-int-cast',
+  '-Wredundant-decls',
+  '-Wshadow',
+  '-Wstrict-prototypes',
+  '-Wundef',
+
+  '-Wno-discarded-array-qualifiers',
+  '-Wno-missing-field-initializers',
+  '-Wno-unused-parameter',
+  '-Wno-missing-declarations',
+
+  '-DWORKBENCH_COMPILATION',
+  '-DWORKBENCH_EXPORT=__attribute__((visibility("default"))) extern',
+]
+libworkbench_link_args = []
+libworkbench_deps = [
+  dependency('gio-2.0', version: '>= 2.76.0'),
+  dependency('gtk4', version: '>= 4.10.0'),
+  dependency('gtksourceview-5', version: '>= 5.8.0'),
+]
+
+if get_option('profile') != 'development'
+  libworkbench_c_args += [
+    '-DG_DISABLE_ASSERT',
+    '-DG_DISABLE_CAST_CHECKS',
+  ]
+endif
+
+libworkbench_headers = files([
+  'workbench.h',
+  'workbench-completion-provider.h',
+  'workbench-completion-request.h',
+])
+
+libworkbench_sources = files([
+  'workbench-completion-provider.c',
+  'workbench-completion-request.c',
+])
+
+install_headers(libworkbench_headers,
+  subdir: join_paths(includedir, 'libworkbench'),
+)
+
+libworkbench_enums = gnome.mkenums_simple('libworkbench-enums',
+         sources: libworkbench_headers,
+       decorator: 'WORKBENCH_EXPORT',
+  install_header: true,
+     install_dir: join_paths(includedir, 'libworkbench'),
+)
+
+libworkbench = shared_library('workbench-@0@'.format(libworkbench_api_version),
+                              libworkbench_headers,
+                              libworkbench_sources,
+                              libworkbench_enums,
+    include_directories: [include_directories('.')],
+           dependencies: libworkbench_deps,
+                 c_args: libworkbench_c_args,
+              link_args: libworkbench_link_args,
+  gnu_symbol_visibility: 'hidden',
+              soversion: meson.project_version(),
+                version: libworkbench_api_version,
+                install: true,
+)
+
+# GObject Introspection
+libworkbench_gir = gnome.generate_gir(libworkbench,
+    identifier_prefix: meson.project_name(),
+            namespace: meson.project_name(),
+            nsversion: libworkbench_api_version,
+        symbol_prefix: meson.project_name().to_lower(),
+              sources: [libworkbench_headers, libworkbench_sources, libworkbench_enums],
+           extra_args: ['--c-include=workbench.h'],
+             includes: ['Gio-2.0', 'Gtk-4.0', 'GtkSource-5'],
+      install_dir_gir: girdir,
+  install_dir_typelib: typelibdir,
+              install: true,
+)
+
+# Vala API Bindings
+libworkbench_vapi = gnome.generate_vapi(libworkbench_api_name,
+       sources: libworkbench_gir[0],
+      packages: ['gio-2.0', 'gtk4', 'gtksourceview-5'],
+       install: true,
+   install_dir: vapidir,
+)

--- a/src/libworkbench/workbench-completion-provider.c
+++ b/src/libworkbench/workbench-completion-provider.c
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Workbench Contributors
+// SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+#include <gio/gio.h>
+#include <gtksourceview/gtksource.h>
+
+#include "libworkbench-enums.h"
+#include "workbench-completion-provider.h"
+#include "workbench-completion-request.h"
+
+
+/**
+ * WorkbenchCompletionProvider:
+ *
+ * A base class for completion providers in Workbench.
+ */
+
+static void gtk_source_completion_provider_iface_init (GtkSourceCompletionProviderInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (WorkbenchCompletionProvider, workbench_completion_provider, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (GTK_SOURCE_TYPE_COMPLETION_PROVIDER, gtk_source_completion_provider_iface_init));
+
+enum {
+  COMPLETION_REQUEST,
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0, };
+
+/**
+ * WorkbenchCompletionProviderClass:
+ * @completion_request: the class closure for #WorkbenchCompletionProvider::completion-request
+ *
+ * The virtual function table for `WorkbenchCompletionProvider`.
+ */
+static void
+workbench_completion_provider_real_completion_request (WorkbenchCompletionProvider *self,
+                                                       WorkbenchCompletionRequest  *request)
+{
+  g_assert (WORKBENCH_IS_COMPLETION_PROVIDER (self));
+  g_assert (WORKBENCH_IS_COMPLETION_REQUEST (request));
+
+  if (!g_signal_has_handler_pending (self, signals [COMPLETION_REQUEST], 0, TRUE))
+    {
+      static gboolean warned = FALSE;
+
+      if (warned)
+        {
+          g_warning ("Your provider does not implement 'completion_request()' "
+                     "and has no handlers connected to 'completion-provider'.");
+          warned = TRUE;
+        }
+
+      workbench_completion_request_state_changed (request,
+                                                  WORKBENCH_REQUEST_STATE_CANCELLED);
+    }
+}
+
+/*
+ * GtkSourceCompletionProvider
+ */
+static GListModel *
+workbench_completion_provider_populate (GtkSourceCompletionProvider  *provider,
+                                        GtkSourceCompletionContext   *context,
+                                        GError                      **error)
+{
+  WorkbenchCompletionProvider *self = WORKBENCH_COMPLETION_PROVIDER (provider);
+  g_autoptr (GListModel) request = NULL;
+
+  g_assert (WORKBENCH_IS_COMPLETION_PROVIDER (self));
+
+  request = g_object_new (WORKBENCH_TYPE_COMPLETION_REQUEST,
+                          "provider", provider,
+                          "context",  context,
+                          NULL);
+  g_signal_emit (G_OBJECT (self), signals [COMPLETION_REQUEST], 0, request);
+
+  return g_steal_pointer (&request);
+}
+
+static void
+on_request_state (WorkbenchCompletionRequest *request,
+                  GParamSpec                 *pspec,
+                  GTask                      *task)
+{
+  if (g_task_return_error_if_cancelled (task))
+    return;
+
+  switch (workbench_completion_request_get_state (request))
+    {
+    case WORKBENCH_REQUEST_STATE_UNKNOWN:
+    case WORKBENCH_REQUEST_STATE_CANCELLED:
+      g_task_return_new_error (task,
+                               G_IO_ERROR,
+                               G_IO_ERROR_CANCELLED,
+                               "Operation cancelled");
+      break;
+
+    case WORKBENCH_REQUEST_STATE_COMPLETE:
+      g_task_return_pointer (task, g_object_ref (request), g_object_unref);
+      break;
+    }
+}
+
+static void
+workbench_completion_provider_populate_async (GtkSourceCompletionProvider *provider,
+                                              GtkSourceCompletionContext  *context,
+                                              GCancellable                *cancellable,
+                                              GAsyncReadyCallback          callback,
+                                              gpointer                     user_data)
+{
+  WorkbenchCompletionProvider *self = WORKBENCH_COMPLETION_PROVIDER (provider);
+  g_autoptr (WorkbenchCompletionRequest) request = NULL;
+  g_autoptr (GTask) task = NULL;
+
+  g_assert (WORKBENCH_IS_COMPLETION_PROVIDER (self));
+
+  request = g_object_new (WORKBENCH_TYPE_COMPLETION_REQUEST,
+                          "provider",    provider,
+                          "context",     context,
+                          "cancellable", cancellable,
+                          NULL);
+
+  /* The request object holds the reference to the task, since it is guaranteed
+   * to emit `notify::complete` before finalization.
+   */
+  task = g_task_new (self, cancellable, callback, user_data);
+  g_task_set_source_tag (task, workbench_completion_provider_populate_async);
+  g_object_set_data_full (G_OBJECT (request),
+                          "workbench-request-task",
+                          g_object_ref (task),
+                          g_object_unref);
+  g_signal_connect_object (request,
+                           "notify::state",
+                           G_CALLBACK (on_request_state),
+                           task, 0);
+
+  g_signal_emit (G_OBJECT (self), signals [COMPLETION_REQUEST], 0, request);
+}
+
+static void
+gtk_source_completion_provider_iface_init (GtkSourceCompletionProviderInterface *iface)
+{
+  iface->populate = workbench_completion_provider_populate;
+  iface->populate_async = workbench_completion_provider_populate_async;
+}
+
+
+/*
+ * GObject
+ */
+static void
+workbench_completion_provider_class_init (WorkbenchCompletionProviderClass *klass)
+{
+  klass->completion_request = workbench_completion_provider_real_completion_request;
+
+  /**
+   * WorkbenchCompletionProvider::completion-request:
+   * @provider: a `WorkbenchCompletionProvider`
+   * @request: a `WorkbenchCompletionRequest`
+   *
+   * Emitted when a request is made for completion proposals.
+   *
+   * This is emitted in place of [vfunc@GtkSource.CompletionProvider.populate]
+   * (both synchronous and asynchronous), with a request object that allows
+   * handlers to negotiate the completion of asynchronous requests manually.
+   */
+  signals [COMPLETION_REQUEST] =
+    g_signal_new ("completion-request",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  G_STRUCT_OFFSET (WorkbenchCompletionProviderClass, completion_request),
+                  NULL, NULL,
+                  g_cclosure_marshal_VOID__OBJECT,
+                  G_TYPE_NONE,
+                  1,
+                  WORKBENCH_TYPE_COMPLETION_REQUEST);
+  g_signal_set_va_marshaller (signals [COMPLETION_REQUEST],
+                              G_TYPE_FROM_CLASS (klass),
+                              g_cclosure_marshal_VOID__OBJECTv);
+}
+
+static void
+workbench_completion_provider_init (WorkbenchCompletionProvider *adapter)
+{
+}

--- a/src/libworkbench/workbench-completion-provider.h
+++ b/src/libworkbench/workbench-completion-provider.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Workbench Contributors
+// SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+#pragma once
+
+#if !defined (WORKBENCH_INSIDE) && !defined (WORKBENCH_COMPILATION)
+# error "Only <workbench.h> can be included directly."
+#endif
+
+#include <gio/gio.h>
+#include <gtksourceview/gtksource.h>
+
+#include "workbench-completion-request.h"
+
+G_BEGIN_DECLS
+
+#define WORKBENCH_TYPE_COMPLETION_PROVIDER (workbench_completion_provider_get_type())
+
+WORKBENCH_EXPORT
+G_DECLARE_DERIVABLE_TYPE (WorkbenchCompletionProvider, workbench_completion_provider, WORKBENCH, COMPLETION_PROVIDER, GObject)
+
+struct _WorkbenchCompletionProviderClass
+{
+  GObjectClass   parent_class;
+
+  /* signal closures */
+  void           (*completion_request) (WorkbenchCompletionProvider *self,
+                                        WorkbenchCompletionRequest  *request);
+
+  /*< private >*/
+  gpointer       padding[8];
+};
+
+G_END_DECLS

--- a/src/libworkbench/workbench-completion-request.c
+++ b/src/libworkbench/workbench-completion-request.c
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Workbench Contributors
+// SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+#include <gio/gio.h>
+#include <gtksourceview/gtksource.h>
+
+#include "libworkbench-enums.h"
+#include "workbench-completion-request.h"
+
+
+/**
+ * WorkbenchCompletionRequest:
+ *
+ * A helper object for [iface@GtkSource.CompletionProvider].
+ *
+ * A `WorkbenchCompletionRequest` instance represents an asynchronous request
+ * for completion suggestions. Specifically, it is an object that can be used
+ * to implement [vfunc@GtkSource.CompletionProvider.populate_async] with more
+ * flexibility for introspected languages.
+ *
+ * Requests are created to populate completion proposals for emissions of
+ * [signal@Workbench.CompletionProvider::completion-request]. Handlers should
+ * call [method@Workbench.CompletionRequest.add] and
+ * [method@Workbench.CompletionRequest.splice] to compose the response, then
+ * set [property@Workbench.CompletionRequest:complete] to %TRUE.
+ */
+
+struct _WorkbenchCompletionRequest
+{
+  GObject                      parent_instance;
+
+  GPtrArray                   *items;
+
+  GCancellable                *cancellable;
+  GtkSourceCompletionContext  *context;
+  GtkSourceCompletionProvider *provider;
+  WorkbenchRequestState        state;
+};
+
+static void   g_list_model_iface_init (GListModelInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (WorkbenchCompletionRequest, workbench_completion_request, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_LIST_MODEL, g_list_model_iface_init))
+
+enum {
+  PROP_0,
+  PROP_CANCELLABLE,
+  PROP_CONTEXT,
+  PROP_ITEM_TYPE,
+  PROP_N_ITEMS,
+  PROP_PROVIDER,
+  PROP_STATE,
+  N_PROPERTIES,
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { 0, };
+
+
+/*
+ * GListModel
+ */
+static gpointer
+workbench_completion_request_get_item (GListModel   *model,
+                                       unsigned int  position)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (model);
+
+  g_assert (WORKBENCH_IS_COMPLETION_REQUEST (self));
+
+  if G_UNLIKELY (position >= self->items->len)
+    return NULL;
+
+  return g_object_ref (g_ptr_array_index (self->items, position));
+}
+
+static GType
+workbench_completion_request_get_item_type (GListModel *model)
+{
+  return GTK_SOURCE_TYPE_COMPLETION_PROPOSAL;
+}
+
+static unsigned int
+workbench_completion_request_get_n_items (GListModel *model)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (model);
+
+  g_assert (WORKBENCH_IS_COMPLETION_REQUEST (self));
+
+  return self->items->len;
+}
+
+static void
+g_list_model_iface_init (GListModelInterface *iface)
+{
+  iface->get_item = workbench_completion_request_get_item;
+  iface->get_item_type = workbench_completion_request_get_item_type;
+  iface->get_n_items = workbench_completion_request_get_n_items;
+}
+
+/*
+ * GObject
+ */
+static void
+workbench_completion_request_dispose (GObject *object)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (object);
+
+  /* Ensure the request is finished */
+  workbench_completion_request_state_changed (self,
+                                              WORKBENCH_REQUEST_STATE_CANCELLED);
+
+  G_OBJECT_CLASS (workbench_completion_request_parent_class)->dispose (object);
+}
+
+static void
+workbench_completion_request_finalize (GObject *object)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (object);
+
+  g_clear_object (&self->cancellable);
+  g_clear_object (&self->context);
+  g_clear_object (&self->provider);
+  g_clear_pointer (&self->items, g_ptr_array_unref);
+
+  G_OBJECT_CLASS (workbench_completion_request_parent_class)->finalize (object);
+}
+
+static void
+workbench_completion_request_get_property (GObject    *object,
+                                           guint       prop_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (object);
+  GListModel *list = G_LIST_MODEL (object);
+
+  switch (prop_id)
+    {
+    case PROP_CANCELLABLE:
+      g_value_set_object (value, self->cancellable);
+      break;
+
+    case PROP_CONTEXT:
+      g_value_set_object (value, self->context);
+      break;
+
+    case PROP_ITEM_TYPE:
+      g_value_set_gtype (value, g_list_model_get_item_type (list));
+      break;
+
+    case PROP_N_ITEMS:
+      g_value_set_uint (value, g_list_model_get_n_items (list));
+      break;
+
+    case PROP_PROVIDER:
+      g_value_set_object (value, self->provider);
+      break;
+
+    case PROP_STATE:
+      g_value_set_enum (value, self->state);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+workbench_completion_request_set_property (GObject      *object,
+                                           guint         prop_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  WorkbenchCompletionRequest *self = WORKBENCH_COMPLETION_REQUEST (object);
+
+  switch (prop_id)
+    {
+    case PROP_CANCELLABLE:
+      self->cancellable = g_value_dup_object (value);
+      break;
+
+    case PROP_CONTEXT:
+      self->context = g_value_dup_object (value);
+      break;
+
+    case PROP_PROVIDER:
+      self->provider = g_value_dup_object (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+workbench_completion_request_class_init (WorkbenchCompletionRequestClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = workbench_completion_request_dispose;
+  object_class->finalize = workbench_completion_request_finalize;
+  object_class->get_property = workbench_completion_request_get_property;
+  object_class->set_property = workbench_completion_request_set_property;
+
+  /**
+   * GtkSourceCompletionContext:cancellable: (getter get_cancellable)
+   *
+   * The [class@Gio.Cancellable] of the request.
+   */
+  properties [PROP_CANCELLABLE] =
+    g_param_spec_object ("cancellable", NULL, NULL,
+                         G_TYPE_CANCELLABLE,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * WorkbenchCompletionRequest:context: (getter get_context)
+   *
+   * The [class@GtkSource.CompletionContext] of the request.
+   */
+  properties [PROP_CONTEXT] =
+    g_param_spec_object ("context", NULL, NULL,
+                         GTK_SOURCE_TYPE_COMPLETION_CONTEXT,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * WorkbenchCompletionRequest:item-type:
+   *
+   * The [class@GtkSource.CompletionProposal] type.
+   */
+  properties [PROP_ITEM_TYPE] =
+    g_param_spec_gtype ("item-type", NULL, NULL,
+                        GTK_SOURCE_TYPE_COMPLETION_PROPOSAL,
+                        (G_PARAM_READABLE |
+                         G_PARAM_EXPLICIT_NOTIFY |
+                         G_PARAM_STATIC_STRINGS));
+
+  /**
+   * WorkbenchCompletionRequest:n-items:
+   *
+   * The current number of proposals.
+   */
+  properties [PROP_N_ITEMS] =
+    g_param_spec_uint ("n-items", NULL, NULL,
+                       0, G_MAXUINT32,
+                       0,
+                       (G_PARAM_READABLE |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
+
+  /**
+   * WorkbenchCompletionRequest:provider: (getter get_provider)
+   *
+   * The [iface@GtkSource.CompletionProvider] of the request.
+   */
+  properties [PROP_PROVIDER] =
+    g_param_spec_object ("provider", NULL, NULL,
+                         GTK_SOURCE_TYPE_COMPLETION_PROVIDER,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * WorkbenchCompletionRequest:state: (getter get_state)
+   *
+   * The state of the request.
+   *
+   * Handlers of the request should update the state of the request by calling
+   * [method@Workbench.CompletionRequest.state_changed].
+   *
+   * If a handler does not change the state, the value is guaranteed to change
+   * to `WORKBENCH_REQUEST_STATE_CANCELLED` before finalization.
+   */
+  properties [PROP_STATE] =
+    g_param_spec_enum ("state", NULL, NULL,
+                       WORKBENCH_TYPE_REQUEST_STATE,
+                       WORKBENCH_REQUEST_STATE_UNKNOWN,
+                       (G_PARAM_READABLE |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+}
+
+static void
+workbench_completion_request_init (WorkbenchCompletionRequest *self)
+{
+  self->items = g_ptr_array_new_with_free_func (g_object_unref);
+}
+
+/**
+ * workbench_completion_request_get_context: (get-property context)
+ *
+ * Get the completion context for the request.
+ *
+ * Returns: (transfer none) (nullable): a `GtkSourceCompletionContext`
+ */
+GtkSourceCompletionContext *
+workbench_completion_request_get_context (WorkbenchCompletionRequest *request)
+{
+  g_return_val_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request), NULL);
+
+  return request->context;
+}
+
+/**
+ * workbench_completion_request_get_provider: (get-property provider)
+ *
+ * Get the completion provider for the request.
+ *
+ * Returns: (transfer none) (nullable): a `GtkSourceCompletionProvider`
+ */
+GtkSourceCompletionProvider *
+workbench_completion_request_get_provider (WorkbenchCompletionRequest *request)
+{
+  g_return_val_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request), NULL);
+
+  return request->provider;
+}
+
+/**
+ * workbench_completion_request_get_state: (get-property state)
+ *
+ * Get the state of the request.
+ *
+ * Returns: a `WorkbenchRequestState`
+ */
+WorkbenchRequestState
+workbench_completion_request_get_state (WorkbenchCompletionRequest *request)
+{
+  g_return_val_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request),
+                        WORKBENCH_REQUEST_STATE_UNKNOWN);
+
+  return request->state;
+}
+
+/**
+ * workbench_completion_request_add:
+ * @request: a `WorkbenchCompletionRequest`
+ * @proposal: a `GtkSourceCompletionProposal`
+ *
+ * Add a [class@GObject.Object] to @request.
+ */
+void
+workbench_completion_request_add (WorkbenchCompletionRequest  *request,
+                                  GtkSourceCompletionProposal *proposal)
+{
+  unsigned int position = 0;
+
+  g_return_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request));
+  g_return_if_fail (GTK_SOURCE_IS_COMPLETION_PROPOSAL (proposal));
+
+  position = request->items->len;
+  g_ptr_array_add (request->items, g_object_ref (proposal));
+  g_list_model_items_changed (G_LIST_MODEL (request), position, 0, 1);
+}
+
+/**
+ * workbench_completion_request_splice:
+ * @request: a `WorkbenchCompletionRequest`
+ * @position: the position at which to make the change
+ * @n_removals: the number of items to remove
+ * @additions: (array length=n_additions) (element-type GtkSource.CompletionProposal): the items to add
+ * @n_additions: the number of items to add
+ *
+ * Changes @request by removing @n_removals items and adding @n_additions.
+ *
+ * The combined value of @position and @n_removals must be less than or equal
+ * to the length of the list at the time this function is called.
+ */
+void
+workbench_completion_request_splice (WorkbenchCompletionRequest *request,
+                                     unsigned int                position,
+                                     unsigned int                n_removals,
+                                     gpointer                   *additions,
+                                     unsigned int                n_additions)
+{
+  g_return_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request));
+  g_return_if_fail (position + n_removals >= position); /* overflow */
+
+  g_ptr_array_remove_range (request->items, position, n_removals);
+
+  for (unsigned int i = 0; i < n_additions; i++)
+    {
+      g_ptr_array_insert (request->items,
+                          position + i,
+                          g_object_ref (additions[i]));
+    }
+
+  g_list_model_items_changed (G_LIST_MODEL (request),
+                              position,
+                              n_removals,
+                              n_additions);
+}
+
+/**
+ * workbench_completion_request_state_changed:
+ * @request: a `WorkbenchCompletionRequest`
+ * @state: a `WorkbenchRequestState`
+ *
+ * Update the state of the request.
+ *
+ * If @state is `WORKBENCH_REQUEST_STATE_CANCELLED`, this will also call
+ * [method@Gio.Cancellable.cancel] on the request's cancellable object.
+ */
+void
+workbench_completion_request_state_changed (WorkbenchCompletionRequest *request,
+                                            WorkbenchRequestState       state)
+{
+  g_return_if_fail (WORKBENCH_IS_COMPLETION_REQUEST (request));
+
+  if (request->state >= state)
+    return;
+
+  if (state == WORKBENCH_REQUEST_STATE_CANCELLED)
+    g_cancellable_cancel (request->cancellable);
+
+  request->state = state;
+  g_object_notify_by_pspec (G_OBJECT (request), properties [PROP_STATE]);
+}

--- a/src/libworkbench/workbench-completion-request.h
+++ b/src/libworkbench/workbench-completion-request.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Workbench Contributors
+// SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+#pragma once
+
+#if !defined (WORKBENCH_INSIDE) && !defined (WORKBENCH_COMPILATION)
+# error "Only <workbench.h> can be included directly."
+#endif
+
+#include <gio/gio.h>
+#include <gtksourceview/gtksource.h>
+
+G_BEGIN_DECLS
+
+/**
+ * WorkbenchRequestState:
+ * @WORKBENCH_REQUEST_STATE_UNKNOWN: the request state is unknown
+ * @WORKBENCH_REQUEST_STATE_CANCELLED: the request was cancelled
+ * @WORKBENCH_REQUEST_STATE_COMPLETE: the request is complete
+ *
+ * Enumeration of request states.
+ */
+typedef enum
+{
+  WORKBENCH_REQUEST_STATE_UNKNOWN,
+  WORKBENCH_REQUEST_STATE_CANCELLED,
+  WORKBENCH_REQUEST_STATE_COMPLETE,
+} WorkbenchRequestState;
+
+
+#define WORKBENCH_TYPE_COMPLETION_REQUEST (workbench_completion_request_get_type())
+
+WORKBENCH_EXPORT
+G_DECLARE_FINAL_TYPE (WorkbenchCompletionRequest, workbench_completion_request, WORKBENCH, COMPLETION_REQUEST, GObject)
+
+WORKBENCH_EXPORT
+GCancellable                * workbench_completion_request_get_cancellable (WorkbenchCompletionRequest  *request);
+WORKBENCH_EXPORT
+GtkSourceCompletionContext  * workbench_completion_request_get_context     (WorkbenchCompletionRequest  *request);
+WORKBENCH_EXPORT
+GtkSourceCompletionProvider * workbench_completion_request_get_provider    (WorkbenchCompletionRequest  *request);
+WORKBENCH_EXPORT
+WorkbenchRequestState         workbench_completion_request_get_state       (WorkbenchCompletionRequest  *request);
+WORKBENCH_EXPORT
+void                          workbench_completion_request_add             (WorkbenchCompletionRequest  *request,
+                                                                            GtkSourceCompletionProposal *proposal);
+WORKBENCH_EXPORT
+void                          workbench_completion_request_splice          (WorkbenchCompletionRequest  *request,
+                                                                            unsigned int                 position,
+                                                                            unsigned int                 n_removals,
+                                                                            gpointer                    *additions,
+                                                                            unsigned int                 n_additions);
+WORKBENCH_EXPORT
+void                          workbench_completion_request_state_changed   (WorkbenchCompletionRequest  *request,
+                                                                            WorkbenchRequestState        state);
+
+G_END_DECLS

--- a/src/libworkbench/workbench.h
+++ b/src/libworkbench/workbench.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: Workbench Contributors
+// SPDX-FileContributor: Andy Holmes <andyholmes@gnome.org>
+
+#pragma once
+
+#define WORKBENCH_INSIDE
+
+#include "libworkbench-enums.h"
+
+#include "workbench-completion-provider.h"
+#include "workbench-completion-request.h"
+
+#undef WORKBENCH_INSIDE
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,3 +68,5 @@ gresource = custom_target('gjspack',
   install_dir: pkgdatadir,
   build_always_stale: true,
 )
+
+subdir('libworkbench')


### PR DESCRIPTION
Functionality that is static and performance sensitive can be moved here as necessary, but more importantly it can be used to work around problems with introspection in GJS.

cc #257