### PR TITLE
Use diagnostics from gtkcsslanguageserver

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -58,3 +58,4 @@ src/IconLibrary/main.blp
 src/IconLibrary/main.js
 src/DocumentationViewer.blp
 src/DocumentationViewer.js
+src/langs/css/css.js

--- a/re.sonny.Workbench.Devel.json
+++ b/re.sonny.Workbench.Devel.json
@@ -185,6 +185,33 @@
       ]
     },
     {
+      "name" : "jsonrpc-glib",
+      "config-opts" : [
+        "--buildtype=debugoptimized",
+        "-Denable_tests=false"
+      ],
+      "buildsystem" : "meson",
+      "builddir" : true,
+      "sources" : [
+            {
+              "type" : "git",
+              "url" : "https://gitlab.gnome.org/GNOME/jsonrpc-glib.git",
+              "branch" : "main"
+            }
+      ]
+    },
+    {
+      "name": "GTKCssLanguageServer",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/JCWasmx86/GTKCssLanguageServer",
+          "branch": "main"
+        }
+      ]
+    },
+    {
       "name": "Workbench",
       "buildsystem": "meson",
       "builddir": true,

--- a/re.sonny.Workbench.Devel.json
+++ b/re.sonny.Workbench.Devel.json
@@ -185,29 +185,30 @@
       ]
     },
     {
-      "name" : "jsonrpc-glib",
-      "config-opts" : [
-        "--buildtype=debugoptimized",
-        "-Denable_tests=false"
-      ],
-      "buildsystem" : "meson",
-      "builddir" : true,
-      "sources" : [
-            {
-              "type" : "git",
-              "url" : "https://gitlab.gnome.org/GNOME/jsonrpc-glib.git",
-              "branch" : "main"
-            }
-      ]
-    },
-    {
       "name": "GTKCssLanguageServer",
+      "config-opts": ["--buildtype=release"],
       "buildsystem": "meson",
+      "builddir": true,
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/JCWasmx86/GTKCssLanguageServer",
-          "branch": "main"
+          "commit": "638bf6e8836d9c2aed6d4c5d17dbf00311155145"
+        }
+      ],
+      "modules": [
+        {
+          "name": "jsonrpc-glib",
+          "config-opts": ["--buildtype=release", "-Denable_tests=false"],
+          "buildsystem": "meson",
+          "builddir": true,
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://download.gnome.org/sources/jsonrpc-glib/3.44/jsonrpc-glib-3.44.0.tar.xz",
+              "sha256": "69406a0250d0cc5175408cae7eca80c0c6bfaefc4ae1830b354c0433bcd5ce06"
+            }
+          ]
         }
       ]
     },

--- a/re.sonny.Workbench.json
+++ b/re.sonny.Workbench.json
@@ -185,29 +185,30 @@
       ]
     },
     {
-      "name" : "jsonrpc-glib",
-      "config-opts" : [
-        "--buildtype=debugoptimized",
-        "-Denable_tests=false"
-      ],
-      "buildsystem" : "meson",
-      "builddir" : true,
-      "sources" : [
-            {
-              "type" : "git",
-              "url" : "https://gitlab.gnome.org/GNOME/jsonrpc-glib.git",
-              "branch" : "main"
-            }
-        ]
-    },
-    {
       "name": "GTKCssLanguageServer",
+      "config-opts": ["--buildtype=release"],
       "buildsystem": "meson",
+      "builddir": true,
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/JCWasmx86/GTKCssLanguageServer",
-          "branch": "main"
+          "commit": "638bf6e8836d9c2aed6d4c5d17dbf00311155145"
+        }
+      ],
+      "modules": [
+        {
+          "name": "jsonrpc-glib",
+          "config-opts": ["--buildtype=release", "-Denable_tests=false"],
+          "buildsystem": "meson",
+          "builddir": true,
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://download.gnome.org/sources/jsonrpc-glib/3.44/jsonrpc-glib-3.44.0.tar.xz",
+              "sha256": "69406a0250d0cc5175408cae7eca80c0c6bfaefc4ae1830b354c0433bcd5ce06"
+            }
+          ]
         }
       ]
     },

--- a/re.sonny.Workbench.json
+++ b/re.sonny.Workbench.json
@@ -185,6 +185,33 @@
       ]
     },
     {
+      "name" : "jsonrpc-glib",
+      "config-opts" : [
+        "--buildtype=debugoptimized",
+        "-Denable_tests=false"
+      ],
+      "buildsystem" : "meson",
+      "builddir" : true,
+      "sources" : [
+            {
+              "type" : "git",
+              "url" : "https://gitlab.gnome.org/GNOME/jsonrpc-glib.git",
+              "branch" : "main"
+            }
+        ]
+    },
+    {
+      "name": "GTKCssLanguageServer",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/JCWasmx86/GTKCssLanguageServer",
+          "branch": "main"
+        }
+      ]
+    },
+    {
       "name": "Workbench",
       "buildsystem": "meson",
       "builddir": true,

--- a/src/PanelStyle.js
+++ b/src/PanelStyle.js
@@ -2,8 +2,9 @@ import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 
 import { settings } from "./util.js";
+import { setup as setupCSS } from "./langs/css/css.js";
 
-export default function PanelStyle({ builder }) {
+export default function PanelStyle({ builder, data_dir, document }) {
   const button_style = builder.get_object("button_style");
   const panel_style = builder.get_object("panel_style");
   settings.bind(
@@ -18,4 +19,5 @@ export default function PanelStyle({ builder }) {
     "visible",
     GObject.BindingFlags.SYNC_CREATE,
   );
+  setupCSS({ data_dir, document });
 }

--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -201,10 +201,6 @@ export default function Internal({
     }
 
     css_provider = new Gtk.CssProvider();
-    css_provider.connect("parsing-error", (_self, section, error) => {
-      const diagnostic = getCssDiagnostic(section, error);
-      builder.get_object("code_view_css").handleDiagnostics([diagnostic]);
-    });
     css_provider.load_from_data(style, -1);
     Gtk.StyleContext.add_provider_for_display(
       output.get_display(),
@@ -283,23 +279,4 @@ function screenshot({ widget, path }) {
   texture.save_to_png(path);
 
   return true;
-}
-
-// Converts a Gtk.CssSection and Gtk.CssError to an LSP diagnostic object
-function getCssDiagnostic(section, error) {
-  const start_location = section.get_start_location();
-  const end_location = section.get_end_location();
-
-  const range = {
-    start: {
-      line: start_location.lines,
-      character: start_location.line_chars,
-    },
-    end: {
-      line: end_location.lines,
-      character: end_location.line_chars,
-    },
-  };
-
-  return { range, message: error.message, severity: 1 };
 }

--- a/src/about.js
+++ b/src/about.js
@@ -67,6 +67,7 @@ ${getBlueprintVersion()}
     "Nasah Kuma https://www.mantohnasah.com/",
     "Jose Hunter https://github.com/halfmexican/",
     "Akunne Pascal https://github.com/Kodecheff",
+    "JCWasmx86 https://github.com/JCWasmx86",
     // Add yourself as
     // "John Doe",
     // or

--- a/src/langs/css/css.js
+++ b/src/langs/css/css.js
@@ -1,0 +1,51 @@
+import Gio from "gi://Gio";
+
+import LSPClient from "../../lsp/LSPClient.js";
+
+export function setup({ data_dir, document }) {
+  const { file, code_view } = document;
+
+  const lspc = createLSPClient({
+    code_view,
+    uri: file.get_uri(),
+    data_dir,
+  });
+
+  lspc.start().catch(logError);
+  code_view.buffer.connect("modified-changed", () => {
+    if (!code_view.buffer.get_modified()) return;
+    lspc.didChange().catch(logError);
+  });
+}
+
+function createLSPClient({ uri, code_view, data_dir }) {
+  const lspc = new LSPClient(["gtkcsslanguageserver"], {
+    rootUri: Gio.File.new_for_path(data_dir).get_uri(),
+    uri,
+    languageId: "css",
+    buffer: code_view.buffer,
+  });
+
+  lspc.connect("exit", () => {
+    console.debug("gtkcsslanguageserver language server exit");
+  });
+  lspc.connect("output", (_self, message) => {
+    console.debug(`gtkcsslanguageserver language server OUT:\n${JSON.stringify(message)}`);
+  });
+  lspc.connect("input", (_self, message) => {
+    console.debug(`gtkcsslanguageserver language server IN:\n${JSON.stringify(message)}`);
+  });
+
+  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics
+  lspc.connect(
+    "notification::textDocument/publishDiagnostics",
+    (_self, params) => {
+      if (params.uri !== uri) {
+        return;
+      }
+      code_view.handleDiagnostics(params.diagnostics);
+    },
+  );
+
+  return lspc;
+}

--- a/src/window.js
+++ b/src/window.js
@@ -6,7 +6,6 @@ import Adw from "gi://Adw";
 import Vte from "gi://Vte";
 import { gettext as _ } from "gettext";
 
-import { setup as setupCSS } from "./langs/css/css.js";
 import * as xml from "./langs/xml/xml.js";
 import {
   settings,
@@ -114,7 +113,6 @@ export default function Window({ application }) {
     file: Gio.File.new_for_path(GLib.build_filenamev([data_dir, "state.css"])),
   });
   langs.css.document = document_css;
-  setupCSS({ data_dir, document: document_css });
 
   const panel_ui = PanelUI({
     application,
@@ -126,7 +124,7 @@ export default function Window({ application }) {
     document_blueprint,
   });
 
-  PanelStyle({ builder, document_css });
+  PanelStyle({ builder, data_dir, document: document_css });
 
   const previewer = Previewer({
     output,

--- a/src/window.js
+++ b/src/window.js
@@ -6,6 +6,7 @@ import Adw from "gi://Adw";
 import Vte from "gi://Vte";
 import { gettext as _ } from "gettext";
 
+import { setup as setupCSS } from "./langs/css/css.js";
 import * as xml from "./langs/xml/xml.js";
 import {
   settings,
@@ -113,6 +114,7 @@ export default function Window({ application }) {
     file: Gio.File.new_for_path(GLib.build_filenamev([data_dir, "state.css"])),
   });
   langs.css.document = document_css;
+  setupCSS({ data_dir, document: document_css });
 
   const panel_ui = PanelUI({
     application,


### PR DESCRIPTION
Fixes #370

Integrates this language server for GTK CSS flavor: https://github.com/JCWasmx86/GTKCssLanguageServer

Currently the diagnostics are complete, hovering are stubs (As I currently don't have the time to copy-paste the description from MDN), auto-completion is barebones.

This code provided here is enough for showing diagnostics. 