### PR TITLE
library: Add Tooltip entry

### DIFF
--- a/src/Library/demos/Tooltip/main.blp
+++ b/src/Library/demos/Tooltip/main.blp
@@ -1,0 +1,81 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.StatusPage {
+  title: _("Tooltip");
+  description: _("Show additional information about controls or app content");
+
+  Box {
+    halign: center;
+    valign: center;
+    spacing: 24;
+    orientation: vertical;
+
+    Box {
+      halign: center;
+      spacing: 24;
+
+      Button {
+        tooltip-text: _("Back");
+        icon-name: "go-previous-symbolic";
+      }
+
+      Button {
+        tooltip-text: _("New Tab");
+        icon-name: "tab-new-filled-symbolic";
+      }
+
+      ToggleButton {
+        tooltip-text: _("Do Not Disturb");
+        icon-name: "bell-large-none-symbolic";
+      }
+
+      ToggleButton {
+        icon-name: "dock-left-symbolic";
+        tooltip-text: _("Toggle Sidebar");
+      }
+    }
+
+    Box {
+      spacing: 24;
+
+      Button {
+        label: _("Open…");
+        tooltip-markup: _("<i>Select a File</i>");
+
+        styles ["pill"]
+      }
+
+      Button button {
+        has-tooltip: true;
+        label: _("Custom");
+      }
+    }
+
+    Box {
+      orientation: vertical;
+
+      LinkButton {
+        label: "Documentation";
+        uri: "https://docs.gtk.org/gtk4/class.Tooltip.html";
+      }
+
+      LinkButton {
+        label: "Human Interface Guidelines";
+        uri: "https://developer.gnome.org/hig/patterns/feedback/tooltips";
+      }
+    }
+  }
+}
+
+Box custom_tooltip {
+  spacing: 6;
+
+  Label {
+    label: "This is a custom tooltip";
+  }
+
+  Image {
+    icon-name: "penguin-alt-symbolic";
+  }
+}

--- a/src/Library/demos/Tooltip/main.blp
+++ b/src/Library/demos/Tooltip/main.blp
@@ -53,10 +53,11 @@ Adw.StatusPage {
     }
 
     Box {
+      spacing: 6;
       orientation: vertical;
 
       LinkButton {
-        label: "Documentation";
+        label: "API Reference";
         uri: "https://docs.gtk.org/gtk4/class.Tooltip.html";
       }
 

--- a/src/Library/demos/Tooltip/main.blp
+++ b/src/Library/demos/Tooltip/main.blp
@@ -67,15 +67,3 @@ Adw.StatusPage {
     }
   }
 }
-
-Box custom_tooltip {
-  spacing: 6;
-
-  Label {
-    label: "This is a custom tooltip";
-  }
-
-  Image {
-    icon-name: "penguin-alt-symbolic";
-  }
-}

--- a/src/Library/demos/Tooltip/main.js
+++ b/src/Library/demos/Tooltip/main.js
@@ -1,0 +1,7 @@
+const button = workbench.builder.get_object("button");
+const custom_tooltip = workbench.builder.get_object("custom_tooltip");
+
+button.connect("query-tooltip", (button, x, y, mode, tooltip) => {
+  tooltip.set_custom(custom_tooltip);
+  return true;
+});

--- a/src/Library/demos/Tooltip/main.js
+++ b/src/Library/demos/Tooltip/main.js
@@ -1,7 +1,14 @@
+import Gtk from "gi://Gtk";
+
 const button = workbench.builder.get_object("button");
-const custom_tooltip = workbench.builder.get_object("custom_tooltip");
 
 button.connect("query-tooltip", (button, x, y, mode, tooltip) => {
+  const custom_tooltip = new Gtk.Box({ spacing: 6 });
+  const label = new Gtk.Label({ label: "This is a custom tooltip" });
+  const icon = new Gtk.Image({ icon_name: "penguin-alt-symbolic" });
+  custom_tooltip.append(label);
+  custom_tooltip.append(icon);
+
   tooltip.set_custom(custom_tooltip);
   return true;
 });

--- a/src/Library/demos/Tooltip/main.json
+++ b/src/Library/demos/Tooltip/main.json
@@ -1,0 +1,7 @@
+{
+  "name": "Tooltip",
+  "category": "feedback",
+  "description": "Show additional information about controls or app content",
+  "panels": ["ui", "preview"],
+  "autorun": true
+}


### PR DESCRIPTION
Closes #422

I'm having some trouble with the custom tooltip. It usually works fine the first time, but then occasionally I get these errors and the tooltip stops working.
```
(re.sonny.Workbench.Devel:4): Gtk-CRITICAL **: 18:00:43.428: gtk_box_append: assertion 'gtk_widget_get_parent (child) == NULL' failed

(re.sonny.Workbench.Devel:4): Gtk-CRITICAL **: 18:00:45.182: gtk_box_remove: assertion 'gtk_widget_get_parent (child) == (GtkWidget *)box' failed
```
