### PR TITLE
library: Add Scrolled Window entry

### DIFF
--- a/src/Library/demos/Scrolled Window/main.blp
+++ b/src/Library/demos/Scrolled Window/main.blp
@@ -1,0 +1,76 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.StatusPage {
+  title: _("Scrolled Window");
+  description: _("A container that makes its child scrollable");
+
+  Adw.Clamp {
+    Box{
+      hexpand: true;
+      vexpand: true;
+      spacing: 12;
+      orientation: vertical;
+
+      Box{
+        halign: center;
+        spacing: 18;
+
+        Label {
+          label: _("Orientation");
+        }
+
+        Box {
+          margin-start: 6;
+          homogeneous: true;
+          halign: center;
+          styles ["linked"]
+
+          ToggleButton toggle_orientation {
+            label: _("Horizontal");
+            active: true;
+          }
+          ToggleButton {
+            label: _("Vertical");
+            group: toggle_orientation;
+          }
+        }
+
+        Label {
+          label: _("Go To");
+        }
+
+        Box{
+
+          Button button_start {
+            label: _("Start");
+          }
+
+          Button button_end {
+            label: _("End");
+          }
+          styles ["linked"]
+        }
+      }
+
+
+
+      ScrolledWindow scrolled_window {
+        margin-bottom: 24;
+        margin-top: 24;
+        has-frame: true;
+        propagate-natural-height: true;
+        max-content-height: 300;
+
+        Box container {
+          homogeneous: true;
+        }
+      }
+
+      LinkButton {
+        label: "Documentation";
+        uri: "https://docs.gtk.org/gtk4/class.ScrolledWindow.html";
+      }
+    }
+  }
+}

--- a/src/Library/demos/Scrolled Window/main.blp
+++ b/src/Library/demos/Scrolled Window/main.blp
@@ -68,7 +68,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "Documentation";
+        label: "API Reference";
         uri: "https://docs.gtk.org/gtk4/class.ScrolledWindow.html";
       }
     }

--- a/src/Library/demos/Scrolled Window/main.js
+++ b/src/Library/demos/Scrolled Window/main.js
@@ -1,0 +1,91 @@
+import Gtk from "gi://Gtk";
+import Adw from "gi://Adw";
+
+const scrolled_window = workbench.builder.get_object("scrolled_window");
+const container = workbench.builder.get_object("container");
+const toggle_orientation = workbench.builder.get_object("toggle_orientation");
+const button_start = workbench.builder.get_object("button_start");
+const button_end = workbench.builder.get_object("button_end");
+
+const scrollbars = [
+  scrolled_window.get_hscrollbar(),
+  scrolled_window.get_vscrollbar(),
+];
+let orientation = 0;
+toggle_orientation.connect("toggled", () => {
+  if (toggle_orientation.active) {
+    container.orientation = Gtk.Orientation.HORIZONTAL;
+    orientation = 0;
+  } else {
+    container.orientation = Gtk.Orientation.VERTICAL;
+    orientation = 1;
+  }
+});
+
+const num_items = 20;
+for (let i = 0; i < num_items; i++) {
+  populateContainer(container, `Item ${i + 1}`);
+}
+
+scrolled_window.connect("edge-reached", () => {
+  console.log("Edge Reached");
+});
+
+button_start.connect("clicked", () => {
+  disableButtons();
+  const scrollbar = scrollbars[orientation];
+  const anim = createScrollbarAnim(scrollbar, 0);
+  anim.play();
+});
+
+button_end.connect("clicked", () => {
+  disableButtons();
+  const scrollbar = scrollbars[orientation];
+  const anim = createScrollbarAnim(scrollbar, 1);
+  anim.play();
+});
+
+function populateContainer(container, label) {
+  const item = new Adw.Bin({
+    margin_top: 6,
+    margin_bottom: 6,
+    margin_start: 6,
+    margin_end: 6,
+    child: new Gtk.Label({
+      label: label,
+      width_request: 100,
+      height_request: 100,
+    }),
+    css_classes: ["card"],
+  });
+  container.append(item);
+}
+
+function disableButtons() {
+  button_end.sensitive = false;
+  button_start.sensitive = false;
+}
+
+function enableButtons() {
+  button_end.sensitive = true;
+  button_start.sensitive = true;
+}
+
+function createScrollbarAnim(scrollbar, direction) {
+  // direction = 0 -> Animates to Start
+  // direction = 1 -> Animates to End
+  const adjustment = scrollbar.adjustment;
+  const target = Adw.PropertyAnimationTarget.new(adjustment, "value");
+  const animation = new Adw.TimedAnimation({
+    widget: scrollbar,
+    value_from: adjustment.value,
+    value_to: direction ? adjustment.upper : 0,
+    duration: 3000,
+    easing: Adw.Easing["LINEAR"],
+    target: target,
+  });
+  animation.connect("done", () => {
+    enableButtons();
+  });
+  return animation;
+}

--- a/src/Library/demos/Scrolled Window/main.js
+++ b/src/Library/demos/Scrolled Window/main.js
@@ -7,6 +7,8 @@ const toggle_orientation = workbench.builder.get_object("toggle_orientation");
 const button_start = workbench.builder.get_object("button_start");
 const button_end = workbench.builder.get_object("button_end");
 
+button_start.sensitive = false;
+
 const scrollbars = [
   scrolled_window.get_hscrollbar(),
   scrolled_window.get_vscrollbar(),
@@ -28,6 +30,11 @@ for (let i = 0; i < num_items; i++) {
 }
 
 scrolled_window.connect("edge-reached", () => {
+  const scrollbar = scrollbars[orientation];
+  const adj = scrollbar.adjustment;
+  // Enable end button if scrollbar is at the start
+  button_end.sensitive = adj.value === adj.lower;
+  button_start.sensitive = !button_end.sensitive;
   console.log("Edge Reached");
 });
 
@@ -62,13 +69,8 @@ function populateContainer(container, label) {
 }
 
 function disableButtons() {
-  button_end.sensitive = false;
   button_start.sensitive = false;
-}
-
-function enableButtons() {
-  button_end.sensitive = true;
-  button_start.sensitive = true;
+  button_end.sensitive = false;
 }
 
 function createScrollbarAnim(scrollbar, direction) {
@@ -79,13 +81,10 @@ function createScrollbarAnim(scrollbar, direction) {
   const animation = new Adw.TimedAnimation({
     widget: scrollbar,
     value_from: adjustment.value,
-    value_to: direction ? adjustment.upper : 0,
-    duration: 3000,
+    value_to: direction ? adjustment.upper - adjustment.page_size : 0,
+    duration: 1000,
     easing: Adw.Easing["LINEAR"],
     target: target,
-  });
-  animation.connect("done", () => {
-    enableButtons();
   });
   return animation;
 }

--- a/src/Library/demos/Scrolled Window/main.json
+++ b/src/Library/demos/Scrolled Window/main.json
@@ -1,0 +1,10 @@
+{
+  "name": "Scrolled Window",
+  "category": "layout",
+  "description": "A container that makes its child scrollable",
+  "panels": [
+    "ui",
+    "preview"
+  ],
+  "autorun": true
+}


### PR DESCRIPTION
Closes #419
There is an edge case where if the Start/End buttons are pressed when it's already at the edge, the buttons get disabled for the animation duration. Is that problematic and if so, what might be the simplest way to handle it?