### PR TITLE
window: Set current demo's name as window title

### DIFF
--- a/data/app.gschema.xml
+++ b/data/app.gschema.xml
@@ -15,6 +15,9 @@
     </key>
   </schema>
   <schema id="@app_id@.Session" path="/re/sonny/Workbench/">
+    <key name="title" type="s">
+      <default>'Workbench'</default>
+    </key>
     <key name="show-code" type="b">
       <default>false</default>
     </key>

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -62,6 +62,7 @@ export function createSessionFromDemo(demo) {
 
   const { panels } = demo;
   const { settings } = session;
+  settings.set_string("title", demo.name);
   settings.set_boolean("show-code", panels.includes("code"));
   settings.set_boolean("show-style", panels.includes("style"));
   settings.set_boolean("show-ui", panels.includes("ui"));

--- a/src/window.js
+++ b/src/window.js
@@ -56,6 +56,7 @@ export default function Window({ application, session }) {
     window.add_css_class("devel");
   }
   window.set_application(application);
+  window.set_title(`Workbench — ${settings.get_string("title")}`);
 
   // Popover menu theme switcher
   const button_menu = builder.get_object("button_menu");


### PR DESCRIPTION
This PR implements a feature that sets the current demo's name as title of the window. While this is not visible in Workbench's UI, it is in GNOME Shell's activities overview and window switcher. This allows the user to find the demo they were working on more easily if they had multiple windows opened.

The name of the demo is also stored in the session's settings so it can be restored.