### PR TITLE
library: Use relative paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,5 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[**.vala]
-indent_size = 4
-
 [{Makefile,**.mk}]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
+[**.vala]
+indent_size = 4
+
 [{Makefile,**.mk}]
 indent_style = tab

--- a/src/Library/Library.js
+++ b/src/Library/Library.js
@@ -76,7 +76,7 @@ async function openDemo({ application, demo_name }) {
   const demo = getDemo(demo_name);
   const session = await createSessionFromDemo(demo);
 
-  const is_js = session.file.get_child("main.js").query_exists(null);
+  const is_js = session.settings.get_int("code-language") === 0;
 
   const { load } = Window({ application, session });
   await load({ run: demo.autorun && is_js });

--- a/src/Library/demos/Audio/main.js
+++ b/src/Library/demos/Audio/main.js
@@ -5,14 +5,14 @@ const controls = workbench.builder.get_object("controls");
 
 const buttons = ["sound", "music"];
 const audio_files = {
-  sound: "Library/demos/Audio/Dog.ogg",
-  music: "Library/demos/Audio/Chopin-nocturne-op-9-no-2.ogg",
+  sound: "./Dog.ogg",
+  music: "./Chopin-nocturne-op-9-no-2.ogg",
 };
 
 buttons.forEach((button_name) => {
   const button = workbench.builder.get_object(`button_${button_name}`);
-  const file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-    audio_files[button_name],
+  const file = Gio.File.new_for_uri(
+    workbench.resolve(audio_files[button_name]),
   );
 
   button.connect("clicked", () => {

--- a/src/Library/demos/Event Controllers/main.js
+++ b/src/Library/demos/Event Controllers/main.js
@@ -4,7 +4,6 @@ import Gio from "gi://Gio";
 
 const window = workbench.window;
 const ctrl_button = workbench.builder.get_object("ctrl_button");
-const click_button = workbench.builder.get_object("click_button");
 const stack = workbench.builder.get_object("stack");
 const pic1 = workbench.builder.get_object("pic1");
 const pic2 = workbench.builder.get_object("pic2");
@@ -12,16 +11,8 @@ const primary_button = workbench.builder.get_object("primary_button");
 const middle_button = workbench.builder.get_object("middle_button");
 const secondary_button = workbench.builder.get_object("secondary_button");
 
-const pic1_file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Event Controllers/image1.png",
-);
-
-const pic2_file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Event Controllers/image2.png",
-);
-
-pic1.file = pic1_file;
-pic2.file = pic2_file;
+pic1.file = Gio.File.new_for_uri(workbench.resolve('image1.png'));
+pic2.file = Gio.File.new_for_uri(workbench.resolve('image2.png'));
 
 let ctrl_pressed = false;
 

--- a/src/Library/demos/Frame/main.js
+++ b/src/Library/demos/Frame/main.js
@@ -1,6 +1,5 @@
 import Gio from "gi://Gio";
 import Gtk from "gi://Gtk";
-import Gdk from "gi://Gdk";
 
 const pic_with_frame = workbench.builder.get_object("with_frame");
 const pic_without_frame = workbench.builder.get_object("without_frame");
@@ -10,9 +9,7 @@ const textview_without_frame = workbench.builder.get_object(
   "textview_without_frame",
 );
 
-const file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Frame/image.png",
-);
+const file = Gio.File.new_for_uri(workbench.resolve("./image.png"));
 
 const buffer = new Gtk.TextBuffer();
 buffer.set_text(

--- a/src/Library/demos/Overlay/main.js
+++ b/src/Library/demos/Overlay/main.js
@@ -1,8 +1,6 @@
 import Gio from "gi://Gio";
 
-const file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Overlay/image.png",
-);
+const file = Gio.File.new_for_uri(workbench.resolve("./image.png"));
 
 const picture = workbench.builder.get_object("picture");
 picture.file = file;

--- a/src/Library/demos/Overlay/main.vala
+++ b/src/Library/demos/Overlay/main.vala
@@ -1,6 +1,8 @@
-#!/usr/bin/env -S vala workbench.vala --pkg gio-2.0 --pkg gtk4 --pkg libadwaita-1
+#!/usr/bin/env -S vala workbench.vala --pkg gio-2.0 --pkg gtk4
 
-var file = File.new_for_uri(workbench.resolve("./image.png"));
+public void main () {
+  var file = File.new_for_uri(workbench.resolve("./image.png"));
 
-var picture = workbench.builder.get_object("picture");
-picture.file = file;
+  var picture = (Gtk.Picture) workbench.builder.get_object("picture");
+  picture.file = file;
+}

--- a/src/Library/demos/Overlay/main.vala
+++ b/src/Library/demos/Overlay/main.vala
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S vala workbench.vala --pkg gio-2.0 --pkg gtk4 --pkg libadwaita-1
+
+var file = File.new_for_uri(workbench.resolve("./image.png"));
+
+var picture = workbench.builder.get_object("picture");
+picture.file = file;

--- a/src/Library/demos/Revealer/main.js
+++ b/src/Library/demos/Revealer/main.js
@@ -7,15 +7,8 @@ const revealer_crossfade = workbench.builder.get_object("revealer_crossfade");
 const image1 = workbench.builder.get_object("image1");
 const image2 = workbench.builder.get_object("image2");
 
-let file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Revealer/image1.png",
-);
-image1.file = file;
-
-file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Revealer/image2.png",
-);
-image2.file = file;
+image1.file = Gio.File.new_for_uri(workbench.resolve("./image1.png"));
+image2.file = Gio.File.new_for_uri(workbench.resolve("./image2.png"));
 
 button_slide.connect("toggled", () => {
   revealer_slide.reveal_child = button_slide.active;

--- a/src/Library/demos/Separator/main.js
+++ b/src/Library/demos/Separator/main.js
@@ -1,13 +1,9 @@
 import Gio from "gi://Gio";
-import Gtk from "gi://Gtk";
-import Gdk from "gi://Gdk";
 
 const picture_one = workbench.builder.get_object("picture_one");
 const picture_two = workbench.builder.get_object("picture_two");
 
-const file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Frame/image.png",
-);
+const file = Gio.File.new_for_uri(workbench.resolve("./image.png"));
 
 picture_one.file = file;
 picture_two.file = file;

--- a/src/Library/demos/Video/main.js
+++ b/src/Library/demos/Video/main.js
@@ -3,8 +3,8 @@ import Gio from "gi://Gio";
 
 const video = workbench.builder.get_object("video");
 
-video.file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Video/workbench-video.mp4",
+video.file = Gio.File.new_for_uri(
+  workbench.resolve("./workbench-video.mp4.png"),
 );
 
 const click_gesture = new Gtk.GestureClick();

--- a/src/Library/demos/Wallpaper/main.js
+++ b/src/Library/demos/Wallpaper/main.js
@@ -2,20 +2,18 @@ import Gio from "gi://Gio";
 import Xdp from "gi://Xdp";
 import XdpGtk from "gi://XdpGtk4";
 
+Gio._promisify(Xdp.Portal.prototype, "set_wallpaper", "set_wallpaper_finish");
+
 const portal = new Xdp.Portal();
 const parent = XdpGtk.parent_new_gtk(workbench.window);
 const button = workbench.builder.get_object("button");
 
-const file = Gio.File.new_for_path(pkg.pkgdatadir).resolve_relative_path(
-  "Library/demos/Wallpaper/wallpaper.png",
-);
-
-Gio._promisify(Xdp.Portal.prototype, "set_wallpaper", "set_wallpaper_finish");
+const uri = workbench.resolve("./wallpaper.png");
 
 async function onClicked() {
   const success = await portal.set_wallpaper(
     parent,
-    file.get_uri(),
+    uri,
     Xdp.WallpaperFlags.PREVIEW |
       Xdp.WallpaperFlags.BACKGROUND |
       Xdp.WallpaperFlags.LOCKSCREEN,

--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -16,6 +16,7 @@ export default function Internal({
   application,
   dropdown_preview_align,
   panel_ui,
+  session,
 }) {
   const bus = {};
   addSignalMethods(bus);
@@ -70,6 +71,9 @@ export default function Internal({
       application,
       builder,
       template,
+      resolve(path) {
+        return session.file.resolve_relative_path(path).get_uri();
+      },
       preview(object) {
         dropdown_preview_align.visible = false;
         dropdown_preview_align.selected = 0;

--- a/src/Previewer/Previewer.js
+++ b/src/Previewer/Previewer.js
@@ -39,6 +39,7 @@ export default function Previewer({
   application,
   term_console,
   settings,
+  session,
 }) {
   let panel_code;
 
@@ -64,6 +65,7 @@ export default function Previewer({
     application,
     dropdown_preview_align,
     panel_ui,
+    session,
   });
   const external = External({
     onWindowChange(open) {
@@ -78,6 +80,7 @@ export default function Previewer({
     output,
     builder,
     panel_ui,
+    session,
   });
 
   const code_view_css = builder.get_object("code_view_css");

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -124,7 +124,9 @@ namespace Workbench {
 
     // filename to loadable module or empty string ("") to just run it again
     // also builder_symbol can be empty. Then the builder object is not handed over to the module
-    public void run (string filename, string run_symbol, string builder_symbol, string window_symbol) {
+    public void run (string filename, string run_symbol, string builder_symbol, string window_symbol, string uri) {
+      void* function;
+
       if (filename == "") {
         if (this.module == null) {
           stderr.printf ("No Module specified yet.\n");
@@ -145,13 +147,16 @@ namespace Workbench {
         }
       }
 
+      this.module.symbol ("set_base_uri", out function);
+      var set_base_uri = (BaseUriFunction) function;
+      set_base_uri (uri);
+
       if (builder_symbol != "") {
         if (this.builder == null) {
           stderr.printf ("No UI definition loaded yet.\n");
           return;
         }
 
-        void* function;
         this.module.symbol (builder_symbol, out function);
         if (function == null) {
           stderr.printf (@"Module does not contain symbol '$builder_symbol'.\n");
@@ -171,7 +176,6 @@ namespace Workbench {
         set_window (this.window);
       }
 
-      void* function;
       this.module.symbol (run_symbol, out function);
       if (function == null) {
         stderr.printf (@"Function '$run_symbol' not found.\n");
@@ -214,6 +218,9 @@ namespace Workbench {
 
     [CCode (has_target=false)]
     private delegate void WindowFunction (Gtk.Window window);
+
+    [CCode (has_target=false)]
+    private delegate void BaseUriFunction (string uri);
 
     private Gtk.Window? window;
     private Gtk.Widget? target;

--- a/src/Previewer/previewer.xml
+++ b/src/Previewer/previewer.xml
@@ -13,6 +13,7 @@
       <arg type="s" name="run_symbol" direction="in"/>
       <arg type="s" name="builder_symbol" direction="in"/>
       <arg type="s" name="window_symbol" direction="in"/>
+      <arg type="s" name="uri" direction="in"/>
     </method>
     <method name="CloseWindow">
     </method>

--- a/src/langs/vala/Compiler.js
+++ b/src/langs/vala/Compiler.js
@@ -57,6 +57,7 @@ export default function Compiler({ session }) {
         "main",
         "set_builder",
         "set_window",
+        session.file.get_uri(),
       );
     } catch (err) {
       logError(err);

--- a/src/langs/vala/workbench-api.vala
+++ b/src/langs/vala/workbench-api.vala
@@ -2,12 +2,20 @@ namespace workbench {
     public static Gtk.Builder builder;
     public static Gtk.Window window;
     public static Adw.Application application;
+    public static string uri;
+    public string resolve (string path) {
+        return File.new_for_uri(workbench.uri).resolve_relative_path(path).get_uri();
+    }
 }
 
 public void set_builder (Gtk.Builder b) {
-	  workbench.builder = b;
+    workbench.builder = b;
 }
 
 public void set_window (Gtk.Window w) {
     workbench.window = w;
+}
+
+public void set_base_uri (string uri) {
+    workbench.uri = uri;
 }

--- a/src/window.js
+++ b/src/window.js
@@ -135,6 +135,7 @@ export default function Window({ application, session }) {
     panel_ui,
     term_console,
     settings,
+    session,
   });
 
   const panel_code = PanelCode({


### PR DESCRIPTION
Fixes https://github.com/sonnyp/Workbench/issues/428 by adding a new `workbench.resolve('./image.png')` API which returns an absolute file URI.

---

Another way to solve it is that when running a session we can set `pwd` to the session folder and make use of `File.new_for_path('./image.png')` in examples.

One issue is that it can't be used with the "inline" JS preview/runner unless
  - each Workbench window becomes a separate process
  - or
  - we disable inline runner for JS and run in a separate process like Vala

We have a similar problem with the console, it prints stdout/stderr of the Workbench process which is shared between windows. 

I'm not sure yet if this is the right way to go. Since we already have a couple of `workbench.x` APIs, I don't think adding a new one is a huge deal. It might also make the migration path easier because `pwd` is error prone.
