### PR TITLE
Remove application in workbench-api.vala

### DIFF
--- a/src/langs/vala/workbench-api.vala
+++ b/src/langs/vala/workbench-api.vala
@@ -1,7 +1,6 @@
 namespace workbench {
     public static Gtk.Builder builder;
     public static Gtk.Window window;
-    public static Adw.Application application;
 }
 
 public void set_builder (Gtk.Builder b) {


### PR DESCRIPTION
As far as I can tell, it is unused
@lw64 