### PR TITLE
Boxed Lists: show off activatable widget property.

### DIFF
--- a/src/Library/demos/Boxed Lists/main.blp
+++ b/src/Library/demos/Boxed Lists/main.blp
@@ -34,6 +34,18 @@ Adw.StatusPage {
           }
         }
 
+        Adw.ActionRow {
+          title: _("ActionRow can have a activatable widget");
+          subtitle: _("Click on the row to activate it");
+          activatable-widget: activatable_toggle;
+
+          [suffix]
+          ToggleButton activatable_toggle {
+            icon-name: "hand-touch-symbolic";
+            valign: center;
+          }
+        }
+
         Adw.EntryRow {
           title: _("A row can be an entry");
         }


### PR DESCRIPTION
Super simple addition, with the release of the new 1.4 row widgets, we are not showing new users how to use ```activatable-widget``` property which is useful for deriving your own custom row widget and etc.