### PR TITLE
library: Added `Button` in rust

### DIFF
--- a/src/Library/demos/Button/code.rs
+++ b/src/Library/demos/Button/code.rs
@@ -1,0 +1,29 @@
+use crate::workbench;
+use adw::prelude::*;
+
+pub fn main() {
+    let button_ids: Vec<&str> = vec![
+        "regular",
+        "flat",
+        "suggested",
+        "destructive",
+        "custom",
+        "disabled",
+        "circular-plus",
+        "circular-minus",
+        "pill",
+        "osd-left",
+        "osd-right",
+    ];
+
+    for id in button_ids {
+        let button: gtk::Button = workbench::builder()
+            .object(id)
+            .expect("Button need to be present.");
+        button.connect_clicked(|button| on_button_clicked(button));
+    }
+}
+
+fn on_button_clicked(button: &gtk::Button) {
+    println!("{} clicked", button.label().unwrap())
+}


### PR DESCRIPTION
Hey! I'm new here, coming from the twig update. :)

I tried porting `Button` library to rust. I need some help completing it.
I couldn't make it work by printing the button name, as it was giving following trait error:
```
error[E0599]: the method `name` exists for struct `Button`, but its trait bounds were not satisfied
  --> code.rs:28:35
   |
28 |       println!("{} clicked", button.name())
   |                                     ^^^^ method cannot be called on `Button` due to unsatisfied trait bounds
   |
```
Currently, I used the button label instead. but it errors out for buttons that do not have any label, like circular-plus, osd-minus etc.

Help needed in making it work.