### PR TITLE
library: Ported `TabView` in rust

### DIFF
--- a/src/Library/demos/Tab View/code.rs
+++ b/src/Library/demos/Tab View/code.rs
@@ -1,6 +1,11 @@
 use crate::workbench;
 use adw::prelude::*;
 
+use crate::glib::clone;
+use gtk::glib;
+use std::cell::Cell;
+use std::rc::Rc;
+
 pub fn main() {
     let tab_view: adw::TabView = workbench::builder()
         .object("tab_view")
@@ -14,24 +19,24 @@ pub fn main() {
     let button_overview: gtk::Button = workbench::builder()
         .object("button_overview")
         .unwrap();
-    let mut tab_count = 1;
+    let tab_count = Rc::new(Cell::new(1));
 
-    button_new_tab.connect_clicked(move |_| {
-        add_page(&tab_view, &mut tab_count);
-    });
-    overview.connect_create_tab(move |_| add_page(&tab_view, &mut tab_count));
+    button_new_tab.connect_clicked(clone!(@weak tab_view, @weak tab_count => move |_| {
+        add_page(&tab_view, &tab_count);
+    }));
+    overview.connect_create_tab(move |_| add_page(&tab_view, &tab_count));
     button_overview.connect_clicked(move |_| overview.set_open(true));
 }
 
-fn add_page(tab_view: &adw::TabView, tab_count: &mut u16) -> adw::TabPage {
-    let title = format!("Tab {}", tab_count);
+fn add_page(tab_view: &adw::TabView, tab_count: &Rc<Cell<i32>>) -> adw::TabPage {
+    let title = format!("Tab {}", tab_count.get());
     let page = create_page(&title);
     let tab_page = tab_view.append(&page);
 
     tab_page.set_title(&title);
     tab_page.set_live_thumbnail(true);
 
-    *tab_count += 1;
+    tab_count.set(tab_count.get() + 1);
     tab_page
 }
 

--- a/src/Library/demos/Tab View/code.rs
+++ b/src/Library/demos/Tab View/code.rs
@@ -1,0 +1,43 @@
+use crate::workbench;
+use adw::prelude::*;
+
+pub fn main() {
+    let tab_view: adw::TabView = workbench::builder()
+        .object("tab_view")
+        .unwrap();
+    let button_new_tab: gtk::Button = workbench::builder()
+        .object("button_new_tab")
+        .unwrap();
+    let overview: adw::TabOverview = workbench::builder()
+        .object("overview")
+        .unwrap();
+    let button_overview: gtk::Button = workbench::builder()
+        .object("button_overview")
+        .unwrap();
+    let mut tab_count = 1;
+
+    button_new_tab.connect_clicked(move |_| {
+        add_page(&tab_view, &mut tab_count);
+    });
+    overview.connect_create_tab(move |_| add_page(&tab_view, &mut tab_count));
+    button_overview.connect_clicked(move |_| overview.set_open(true));
+}
+
+fn add_page(tab_view: &adw::TabView, tab_count: &mut u16) -> adw::TabPage {
+    let title = format!("Tab {}", tab_count);
+    let page = create_page(&title);
+    let tab_page = tab_view.append(&page);
+
+    tab_page.set_title(&title);
+    tab_page.set_live_thumbnail(true);
+
+    *tab_count += 1;
+    tab_page
+}
+
+fn create_page(title: &str) -> adw::StatusPage {
+    adw::StatusPage::builder()
+        .title(title)
+        .vexpand(true)
+        .build()
+}


### PR DESCRIPTION
Tried porting `TabView` library in rust.

Currently has an error related to `mut` in closure function. Can't seem to fix on my own.

<details>
  <summary>Error log</summary>

```
error[E0596]: cannot borrow `tab_count` as mutable, as it is a captured variable in a `Fn` closure
  --> code.rs:12:29
   |
12 |         add_page(&tab_view, &mut tab_count);
   |                             ^^^^^^^^^^^^^^ cannot borrow as mutable

error[E0596]: cannot borrow `tab_count` as mutable, as it is a captured variable in a `Fn` closure
  --> code.rs:14:62
   |
14 |     overview.connect_create_tab(move |_| add_page(&tab_view, &mut tab_count));
   |                                                              ^^^^^^^^^^^^^^ cannot borrow as mutable

warning: variable does not need to be mutable
 --> code.rs:9:9
  |
9 |     let mut tab_count = 1;
  |         ----^^^^^^^^^
  |         |
  |         help: remove this `mut`
  |
  = note: `#[warn(unused_mut)]` on by default

error[E0382]: use of moved value: `tab_view`
  --> code.rs:14:33
   |
5  |     let tab_view: adw::TabView = workbench::builder().object("tab_view").unwrap();
   |         -------- move occurs because `tab_view` has type `TabView`, which does not implement the `Copy` trait
...
11 |     button_new_tab.connect_clicked(move |_| {
   |                                    -------- value moved into closure here
12 |         add_page(&tab_view, &mut tab_count);
   |                   -------- variable moved due to use in closure
13 |     });
14 |     overview.connect_create_tab(move |_| add_page(&tab_view, &mut tab_count));
   |                                 ^^^^^^^^           -------- use occurs due to use in closure
   |                                 |
   |                                 value used here after move
```

</details>

Need help in fixing it. Thanks in advance.