### PR TITLE
library: ported `Overlay` in rust

### DIFF
--- a/src/Library/demos/Overlay/code.rs
+++ b/src/Library/demos/Overlay/code.rs
@@ -1,0 +1,8 @@
+use crate::workbench;
+use gtk::gio;
+
+pub fn main() {
+    let file = gio::File::for_uri(workbench::resolve("./image.png").as_str());
+    let picture: gtk::Picture = workbench::builder().object("picture").unwrap();
+    picture.set_file(Some(&file));
+}


### PR DESCRIPTION
Added RUST code for Overlay.

Please review. 