### PR TITLE
library: ported `Menu Button` in Rust

### DIFF
--- a/src/Library/demos/Link Button/code.rs
+++ b/src/Library/demos/Link Button/code.rs
@@ -9,7 +9,8 @@ pub fn main() {
 
     linkbutton.connect_activate_link(|button| {
         println!("About to activate {}", button.uri());
-
+        // Return true if handling the link manually, or
+        // false to let the default behavior continue
         false.into()
     });
 }

--- a/src/Library/demos/Link Button/code.rs
+++ b/src/Library/demos/Link Button/code.rs
@@ -1,16 +1,18 @@
 use crate::workbench;
 use gtk::prelude::*;
+use gtk::traits::ButtonExt;
 
 pub fn main() {
     let linkbutton: gtk::LinkButton = workbench::builder().object("linkbutton").unwrap();
+
     linkbutton.connect_clicked(move |_| {
         println!("Link has been visited");
     });
 
-    linkbutton.connect_activate_link(|button| {
+    linkbutton.connect_notify(Some("visited"), |button, _| {
         println!("About to activate {}", button.uri());
-        // Return true if handling the link manually, or
+      // Return true if handling the link manually, or
         // false to let the default behavior continue
-        false.into()
+        false;
     });
 }

--- a/src/Library/demos/Link Button/code.rs
+++ b/src/Library/demos/Link Button/code.rs
@@ -1,0 +1,15 @@
+use crate::workbench;
+use gtk::prelude::*;
+
+pub fn main() {
+    let linkbutton: gtk::LinkButton = workbench::builder().object("linkbutton").unwrap();
+    linkbutton.connect_clicked(move |_| {
+        println!("Link has been visited");
+    });
+
+    linkbutton.connect_activate_link(|button| {
+        println!("About to activate {}", button.uri());
+
+        false.into()
+    });
+}

--- a/src/Library/demos/Menu Button/code.rs
+++ b/src/Library/demos/Menu Button/code.rs
@@ -1,0 +1,23 @@
+use crate::workbench;
+use gtk::prelude::*;
+use gtk::{Button, Switch};
+
+pub fn main() {
+    let circular_switch: Switch = workbench::builder()
+        .object("circular_switch")
+        .expect("Failed to get circular_switch");
+    let primary_button: Button = workbench::builder()
+        .object("primary")
+        .expect("Failed to get primary_button");
+    let secondary_button: Button = workbench::builder()
+        .object("secondary")
+        .expect("Failed to get secondary_button");
+
+    circular_switch.connect_active_notify(move |switch| {
+        if switch.is_active() {
+            secondary_button.add_css_class("circular");
+        } else {
+            secondary_button.remove_css_class("circular");
+        }
+    });
+}

--- a/src/Library/demos/Separator/code.rs
+++ b/src/Library/demos/Separator/code.rs
@@ -1,0 +1,12 @@
+use crate::workbench;
+use gtk::gio;
+
+pub fn main() {
+    let picture_one: gtk::Picture = workbench::builder().object("picture_one").unwrap();
+    let picture_two: gtk::Picture = workbench::builder().object("picture_two").unwrap();
+
+    let file = gio::File::for_uri(workbench::resolve("./image.png").as_str());
+
+    picture_one.set_file(Some(&file));
+    picture_two.set_file(Some(&file));
+}


### PR DESCRIPTION
Added menu button implementation in rust.
Preview looks fine, but two errors are seen on the console that I cant seem to understand what they are about
They dont seem to effect the preview or Rust code.
![image](https://github.com/sonnyp/Workbench/assets/111046732/24749b46-6123-4431-be3e-5bdc8e37519d)

Review please!