### PR TITLE
Handle Rust errors properly

### DIFF
--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -122,7 +122,7 @@ namespace Workbench {
       Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), this.css , Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
-    public void run (string filename, string uri) {
+    public void run (string filename, string uri) throws DBusError {
       if (this.module != null) {
         this.module.close ();
       }
@@ -159,7 +159,7 @@ namespace Workbench {
       var main_function = (MainFunction) function;
       int result = main_function ();
       if (result != 1) {
-            throw new GLib.DBusError.SPAWN_CHILD_EXITED("demo exited with error code 1");
+            throw new DBusError.SPAWN_CHILD_EXITED("demo exited with error code 1");
       }
     }
 

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -157,7 +157,10 @@ namespace Workbench {
         return;
       }
       var main_function = (MainFunction) function;
-      main_function ();
+      int result = main_function ();
+      if (result != 1) {
+            throw new GLib.DBusError.SPAWN_CHILD_EXITED("demo exited with error code 1");
+      }
     }
 
     public void close_window () {
@@ -185,7 +188,7 @@ namespace Workbench {
     public signal void css_parser_error (string message, int start_line, int start_char, int end_line, int end_char);
 
     [CCode (has_target=false)]
-    private delegate void MainFunction ();
+    private delegate int MainFunction ();
 
     [CCode (has_target=false)]
     private delegate void BuilderFunction (Gtk.Builder builder);

--- a/src/langs/rust/template/lib.rs
+++ b/src/langs/rust/template/lib.rs
@@ -14,8 +14,13 @@ static mut URI: Option<String> = None;
 
 #[no_mangle]
 extern "C" fn main() -> c_int {
-    code::main();
-    EXIT_SUCCESS
+    let result = std::panic::catch_unwind(code::main);
+
+    if result.is_ok() {
+        EXIT_SUCCESS
+    } else {
+        EXIT_FAILURE
+    }
 }
 
 #[no_mangle]
@@ -38,11 +43,10 @@ extern "C" fn set_window(window_ptr: *mut gtk::ffi::GtkWindow) -> c_int {
 
 #[no_mangle]
 extern "C" fn set_base_uri(c_string: *const c_char) -> c_int {
+    if c_string.is_null() {
+        return EXIT_FAILURE;
+    }
     unsafe {
-        if c_string.is_null() {
-            return EXIT_FAILURE;
-        }
-
         let c_str = CStr::from_ptr(c_string);
         if let Ok(str_slice) = c_str.to_str() {
             URI = Some(str_slice.to_string());
@@ -50,3 +54,4 @@ extern "C" fn set_base_uri(c_string: *const c_char) -> c_int {
     }
     EXIT_SUCCESS
 }
+

--- a/src/langs/rust/template/lib.rs
+++ b/src/langs/rust/template/lib.rs
@@ -16,10 +16,11 @@ static mut URI: Option<String> = None;
 extern "C" fn main() -> c_int {
     let result = std::panic::catch_unwind(code::main);
 
-    if result.is_ok() {
-        EXIT_SUCCESS
-    } else {
+    if let Err(err) = result {
+        eprintln!("{err}");
         EXIT_FAILURE
+    } else {
+        EXIT_SUCCESS
     }
 }
 


### PR DESCRIPTION
This way, the rust shared library returns 1 when a panic is handled.
I tried to modify `previewer.vala` to handle that, but I couldn't get anything to work.
Maybe @lw64 can take over that part? 😇

Fixes #557