### PR TITLE
library: Ported Popover in RUST

### DIFF
--- a/src/Library/demos/Popovers/code.rs
+++ b/src/Library/demos/Popovers/code.rs
@@ -8,8 +8,8 @@ pub fn main() {
         let popover: gtk::Popover = workbench::builder().object(id).unwrap();
 
         popover.connect_closed(move |popover| {
-            let popover_name = popover.name();
-            println!("{} closed.", popover_name);
+            let popover_name = popover.widget_name();
+            println!("{popover_name} closed.")
         });
     }
 }

--- a/src/Library/demos/Popovers/code.rs
+++ b/src/Library/demos/Popovers/code.rs
@@ -1,0 +1,15 @@
+use crate::workbench;
+use gtk::prelude::*;
+
+pub fn main() {
+    let popover_ids = ["plain_popover", "popover_menu"];
+
+    for id in popover_ids {
+        let popover: gtk::Popover = workbench::builder().object(id).unwrap();
+
+        popover.connect_closed(move |popover| {
+            let popover_name = popover.name();
+            println!("{} closed.", popover_name);
+        });
+    }
+}


### PR DESCRIPTION
Tried to port Popover, however I am facing a problem as I have been unable to find a function to fetch the name of the popover. It says the .name() function exists, however I can't get it to work. Need some assistance.

Thanks a lot.