### PR TITLE
Freedesktop 23.08

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ SHELL:=/bin/bash -O globstar
 
 setup:
 	flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-	flatpak install --user --noninteractive flathub-beta org.gnome.Sdk//45beta org.freedesktop.Sdk.Extension.rust-stable//23.08beta org.freedesktop.Sdk.Extension.node18//23.08beta
+	flatpak install --or-update --user --noninteractive flathub-beta org.gnome.Platform//45beta org.gnome.Sdk//45beta org.gnome.Sdk.Docs//45beta
 	flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-	flatpak install --user --noninteractive flathub org.flatpak.Builder
+	flatpak install --or-update --user --noninteractive flathub org.flatpak.Builder org.freedesktop.Sdk//23.08 org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.node18//23.08 org.freedesktop.Sdk.Extension.vala//23.08 org.freedesktop.Sdk.Extension.llvm16//23.08
 	npm install
 
 lint:

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -118,7 +118,7 @@ namespace Workbench {
         var end = section.get_end_location();
         this.css_parser_error(error.message, (int)start.lines, (int)start.line_chars, (int)end.lines, (int)end.line_chars);
       });
-      this.css.load_from_data (content, -1);
+      this.css.load_from_data (content.data);
       Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), this.css , Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 


### PR DESCRIPTION
Build currently fails if you update `org.gnome.Sdk//45beta` - this fixes it.