### PR TITLE
fix: remove -fvisibility=hidden

### DIFF
--- a/src/libworkbench/meson.build
+++ b/src/libworkbench/meson.build
@@ -41,7 +41,6 @@ libworkbench_c_args = [
   '-Wno-missing-declarations',
 
   '-DWORKBENCH_COMPILATION',
-  '-DWORKBENCH_EXPORT=__attribute__((visibility("default"))) extern',
 ]
 libworkbench_link_args = []
 libworkbench_deps = [
@@ -74,7 +73,6 @@ install_headers(libworkbench_headers,
 
 libworkbench_enums = gnome.mkenums_simple('libworkbench-enums',
          sources: libworkbench_headers,
-       decorator: 'WORKBENCH_EXPORT',
   install_header: true,
      install_dir: join_paths(includedir, 'libworkbench'),
 )
@@ -87,7 +85,6 @@ libworkbench = shared_library('workbench-@0@'.format(libworkbench_api_version),
            dependencies: libworkbench_deps,
                  c_args: libworkbench_c_args,
               link_args: libworkbench_link_args,
-  gnu_symbol_visibility: 'hidden',
               soversion: meson.project_version(),
                 version: libworkbench_api_version,
                 install: true,

--- a/src/libworkbench/workbench-completion-provider.h
+++ b/src/libworkbench/workbench-completion-provider.h
@@ -17,7 +17,6 @@ G_BEGIN_DECLS
 
 #define WORKBENCH_TYPE_COMPLETION_PROVIDER (workbench_completion_provider_get_type())
 
-WORKBENCH_EXPORT
 G_DECLARE_DERIVABLE_TYPE (WorkbenchCompletionProvider, workbench_completion_provider, WORKBENCH, COMPLETION_PROVIDER, GObject)
 
 struct _WorkbenchCompletionProviderClass

--- a/src/libworkbench/workbench-completion-request.h
+++ b/src/libworkbench/workbench-completion-request.h
@@ -31,27 +31,19 @@ typedef enum
 
 #define WORKBENCH_TYPE_COMPLETION_REQUEST (workbench_completion_request_get_type())
 
-WORKBENCH_EXPORT
 G_DECLARE_FINAL_TYPE (WorkbenchCompletionRequest, workbench_completion_request, WORKBENCH, COMPLETION_REQUEST, GObject)
 
-WORKBENCH_EXPORT
 GCancellable                * workbench_completion_request_get_cancellable (WorkbenchCompletionRequest  *request);
-WORKBENCH_EXPORT
 GtkSourceCompletionContext  * workbench_completion_request_get_context     (WorkbenchCompletionRequest  *request);
-WORKBENCH_EXPORT
 GtkSourceCompletionProvider * workbench_completion_request_get_provider    (WorkbenchCompletionRequest  *request);
-WORKBENCH_EXPORT
 WorkbenchRequestState         workbench_completion_request_get_state       (WorkbenchCompletionRequest  *request);
-WORKBENCH_EXPORT
 void                          workbench_completion_request_add             (WorkbenchCompletionRequest  *request,
                                                                             GtkSourceCompletionProposal *proposal);
-WORKBENCH_EXPORT
 void                          workbench_completion_request_splice          (WorkbenchCompletionRequest  *request,
                                                                             unsigned int                 position,
                                                                             unsigned int                 n_removals,
                                                                             gpointer                    *additions,
                                                                             unsigned int                 n_additions);
-WORKBENCH_EXPORT
 void                          workbench_completion_request_state_changed   (WorkbenchCompletionRequest  *request,
                                                                             WorkbenchRequestState        state);
 


### PR DESCRIPTION
This is an internal library anyways and seemed to be causing some problems, or at least warnings, when compiling other parts of Workbench.