### PR TITLE
Use runtime extensions for language dependencies, don't copy em

### DIFF
--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -4,11 +4,22 @@
   "runtime-version": "45beta",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.vala",
     "org.gnome.Sdk.Docs",
+    "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm16"
   ],
+  "add-extensions": {
+    "org.freedesktop.Sdk.Extension.vala": {
+      "version": "23.08"
+    },
+    "org.freedesktop.Sdk.Extension.rust-stable": {
+      "version": "23.08"
+    },
+    "org.freedesktop.Sdk.Extension.llvm16": {
+      "version": "23.08"
+    }
+  },
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/vala/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib",
@@ -65,13 +76,7 @@
         "rm -rf /app/share/doc/appstream",
         "cp -a /usr/share/gtk-doc/html/. /app/share/doc/",
         "rm -rf /app/share/doc/appstream",
-        "cp -a /usr/share/doc/. /app/share/doc/",
-        "cp -a /usr/lib/sdk/vala/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/vala/lib/. /app/lib/",
-        "cp -a /usr/lib/sdk/rust-stable/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/rust-stable/lib/. /app/lib/",
-        "cp -a /usr/lib/sdk/llvm16/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/llvm16/lib/. /app/lib/"
+        "cp -a /usr/share/doc/. /app/share/doc/"
       ]
     }
   ]

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -4,11 +4,22 @@
   "runtime-version": "45beta",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.vala",
     "org.gnome.Sdk.Docs",
+    "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm16"
   ],
+  "add-extensions": {
+    "org.freedesktop.Sdk.Extension.vala": {
+      "version": "23.08"
+    },
+    "org.freedesktop.Sdk.Extension.rust-stable": {
+      "version": "23.08"
+    },
+    "org.freedesktop.Sdk.Extension.llvm16": {
+      "version": "23.08"
+    }
+  },
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/vala/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib",
@@ -66,12 +77,7 @@
         "cp -a /usr/share/gtk-doc/html/. /app/share/doc/",
         "rm -rf /app/share/doc/appstream",
         "cp -a /usr/share/doc/. /app/share/doc/",
-        "cp -a /usr/lib/sdk/vala/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/vala/lib/. /app/lib/",
-        "cp -a /usr/lib/sdk/rust-stable/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/rust-stable/lib/. /app/lib/",
-        "cp -a /usr/lib/sdk/llvm16/bin/. /app/bin/",
-        "cp -a /usr/lib/sdk/llvm16/lib/. /app/lib/"
+        "cp -a /usr/lib/sdk/vala/bin/. /app/bin/"
       ]
     }
   ]


### PR DESCRIPTION
Makes it easier to get things like bugfixes for Rust faster.

Needs *lots* of testing, and I'm not sure this'll even work. But it's an attempt.