### PR TITLE
build(ci): build flatpak in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,11 +1,14 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   CI:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,3 +33,23 @@ jobs:
           key: 45beta
 
       - run: make ci
+
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Install Extensions
+        run: |
+          flatpak --system install -y --noninteractive org.freedesktop.Sdk.Extension.vala/x86_64/23.08 org.freedesktop.Sdk.Extension.rust-stable/x86_64/23.08 org.freedesktop.Sdk.Extension.llvm16/x86_64/23.08
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: workbench.flatpak
+          repository-name: flathub-beta
+          manifest-path: build-aux/re.sonny.Workbench.Devel.json
+          cache-key: flatpak-builder-${{ github.sha }}

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -58,7 +58,7 @@
       "sources": [
         {
           "type": "dir",
-          "path": "."
+          "path": "../"
         }
       ],
       "post-install": [


### PR DESCRIPTION
Fixes https://github.com/sonnyp/Workbench/issues/599.
Adds a new GitHub action that builds Workbench in the CI. The finished Flatpak is automatically uploaded as an artifact.
As it currently uses the 45beta runtime, the non-beta extensions need to be installed manually.