### PR TITLE
WIP: library: add CSS Gradient entry

### DIFF
--- a/src/Library/demos/CSS Gradient/main.blp
+++ b/src/Library/demos/CSS Gradient/main.blp
@@ -1,0 +1,20 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.StatusPage {
+  title: "CSS Gradient";
+  description: _("Give Gtk widgets a psychedelic touch");
+
+  Box {
+    orientation: vertical;
+    halign: center;
+
+    Button regular {
+      name: "primary";
+      label: "Regular";
+      styles ["pill", "psychedelic-pill"]
+    }
+  }
+  styles ["psychedelic-bg"]
+}
+

--- a/src/Library/demos/CSS Gradient/main.css
+++ b/src/Library/demos/CSS Gradient/main.css
@@ -1,0 +1,17 @@
+/* A static gradient background for the outer box */
+.psychedelic-bg {
+	background: linear-gradient(15deg, #001430, #242424, #140000);
+	background-size: 100% 100%;
+}
+/* The top window borders are normally removed if psychedelic-bg is used on the whole window */
+.psychedelic-bg headerbar {
+  border: none;
+  box-shadow: none;
+}
+
+/* A rainbow sliding gradient for the pill widget itself */
+.psychedelic-pill{
+	background: linear-gradient(-45deg, #ed7650, #e5307f, #24a4d2, #24d8af);
+	background-size: 400% 400%;
+	animation: gradient 15s ease infinite;
+}

--- a/src/Library/demos/CSS Gradient/main.json
+++ b/src/Library/demos/CSS Gradient/main.json
@@ -1,0 +1,6 @@
+{
+  "category": "controls",
+  "description": "Add an animated CSS gradient to spice up your widgets",
+  "panels": ["ui", "preview"],
+  "autorun": true
+}


### PR DESCRIPTION
Adds the "psychedelic" CSS gradient from the Berlin45 hackfest

[WIP] because the button's animated gradient does not slide in the Workbench UI for some reason. This is also a bug I encountered in older Gtk versions