### PR TITLE
Translate all the things

### DIFF
--- a/src/Library/demos/About Window/main.blp
+++ b/src/Library/demos/About Window/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "About Window";
+  title: _("About Window");
   description: _("A window showing information about the application.");
 
   Box {

--- a/src/Library/demos/About Window/main.blp
+++ b/src/Library/demos/About Window/main.blp
@@ -16,7 +16,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.AboutWindow.html";
     }
   }

--- a/src/Library/demos/Accessibility/main.blp
+++ b/src/Library/demos/Accessibility/main.blp
@@ -139,7 +139,7 @@ Adw.StatusPage {
           accessible-role: list_item;
 
           LinkButton {
-            label: "GNOME Developer Documentation";
+            label: _("GNOME Developer Documentation");
             uri: "https://developer.gnome.org/documentation/guidelines/accessibility.html";
           }
         }
@@ -148,7 +148,7 @@ Adw.StatusPage {
           accessible-role: list_item;
 
           LinkButton {
-            label: "GNOME Human Interface Guidelines";
+            label: _("GNOME Human Interface Guidelines");
             uri: "https://developer.gnome.org/hig/guidelines/accessibility.html";
           }
         }

--- a/src/Library/demos/Account/main.blp
+++ b/src/Library/demos/Account/main.blp
@@ -70,7 +70,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://libportal.org/method.Portal.get_user_information.html";
       }
     }

--- a/src/Library/demos/Actions/main.blp
+++ b/src/Library/demos/Actions/main.blp
@@ -158,12 +158,12 @@ Adw.StatusPage demo {
         halign: center;
 
         LinkButton {
-          label: "GJS Guide";
+          label: _("GJS Guide");
           uri: "https://gjs.guide/guides/gio/actions-and-menus.html";
         }
 
         LinkButton {
-          label: "GTK Documentation";
+          label: _("GTK Documentation");
           uri: "https://docs.gtk.org/gtk4/actions.html";
         }
       }

--- a/src/Library/demos/Actions/main.blp
+++ b/src/Library/demos/Actions/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage demo {
-  title: "Actions";
+  title: _("Actions");
   description: _("A high-level interface used to describe a piece of functionality");
 
   Adw.Clamp {

--- a/src/Library/demos/Advanced Buttons/main.blp
+++ b/src/Library/demos/Advanced Buttons/main.blp
@@ -68,7 +68,7 @@ Adw.StatusPage {
 
     LinkButton {
       margin-bottom: 36;
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.SplitButton.html";
     }
 
@@ -152,7 +152,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.ButtonContent.html";
     }
   }

--- a/src/Library/demos/Animation/main.blp
+++ b/src/Library/demos/Animation/main.blp
@@ -117,25 +117,25 @@ Adw.Clamp {
       orientation: vertical;
 
       Label {
-        label: "Tools";
+        label: _("Tools");
         styles ["title-2"]
       }
       LinkButton {
         margin-bottom: 12;
-        label: "Elastic";
+        label: _("Elastic");
         uri: "https://apps.gnome.org/app/app.drey.Elastic/";
       }
       Label {
-        label: "API References";
+        label: _("API References");
         margin-top: 12;
         styles ["title-2"]
       }
       LinkButton {
-        label: "Timed Animation";
+        label: _("Timed Animation");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.TimedAnimation.html";
       }
       LinkButton {
-        label: "Spring Animation";
+        label: _("Spring Animation");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.SpringAnimation.html";
       }
     }

--- a/src/Library/demos/Audio/main.blp
+++ b/src/Library/demos/Audio/main.blp
@@ -35,12 +35,12 @@ Adw.StatusPage {
       orientation: vertical;
 
       LinkButton {
-        label: "MediaControls API Reference";
+        label: _("MediaControls API Reference");
         uri: "https://docs.gtk.org/gtk4/class.MediaControls.html";
       }
 
       LinkButton {
-        label: "MediaFile API Reference";
+        label: _("MediaFile API Reference");
         uri: "https://docs.gtk.org/gtk4/class.MediaFile.html";
       }
     }

--- a/src/Library/demos/Audio/main.blp
+++ b/src/Library/demos/Audio/main.blp
@@ -35,12 +35,12 @@ Adw.StatusPage {
       orientation: vertical;
 
       LinkButton {
-        label: _("MediaControls API Reference");
+        label: _("Media Controls API Reference");
         uri: "https://docs.gtk.org/gtk4/class.MediaControls.html";
       }
 
       LinkButton {
-        label: _("MediaFile API Reference");
+        label: _("Media File API Reference");
         uri: "https://docs.gtk.org/gtk4/class.MediaFile.html";
       }
     }

--- a/src/Library/demos/Avatar/main.blp
+++ b/src/Library/demos/Avatar/main.blp
@@ -17,7 +17,7 @@ Adw.StatusPage {
     }
 
     Label {
-      label: "Initials";
+      label: _("Initials");
       margin-bottom: 30;
     }
 
@@ -41,12 +41,12 @@ Adw.StatusPage {
     }
 
     Label {
-      label: "Fallback";
+      label: _("Fallback");
       margin-bottom: 30;
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Avatar.html";
     }
   }

--- a/src/Library/demos/Avatar/main.blp
+++ b/src/Library/demos/Avatar/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Avatar";
+  title: _("Avatar");
   description: "Display a round avatar for image or initials.";
 
   Box {

--- a/src/Library/demos/Banner/main.blp
+++ b/src/Library/demos/Banner/main.blp
@@ -33,12 +33,12 @@ Adw.ToastOverlay overlay {
           orientation: vertical;
 
           LinkButton {
-            label: "API Reference";
+            label: _("API Reference");
             uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Banner.html";
           }
 
           LinkButton {
-            label: "Human Interface Guidelines";
+            label: _("Human Interface Guidelines");
             uri: "https://developer.gnome.org/hig/patterns/feedback/banners.html";
           }
         }

--- a/src/Library/demos/Box/main.blp
+++ b/src/Library/demos/Box/main.blp
@@ -8,7 +8,7 @@ Adw.Clamp {
     orientation: vertical;
 
     Label {
-      label: "Box";
+      label: _("Box");
       margin-top: 12;
       margin-bottom: 12;
       styles [
@@ -26,12 +26,12 @@ Adw.Clamp {
       margin-bottom: 12;
 
       LinkButton{
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/box.html";
       }
 
       LinkButton{
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.Box.html";
       }
     }

--- a/src/Library/demos/Boxed Lists/main.blp
+++ b/src/Library/demos/Boxed Lists/main.blp
@@ -90,12 +90,12 @@ Adw.StatusPage {
 
       LinkButton {
         margin-top: 24;
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/boxed-lists.html";
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/containers/boxed-lists.html";
       }
     }

--- a/src/Library/demos/Breakpoints/main.blp
+++ b/src/Library/demos/Breakpoints/main.blp
@@ -38,12 +38,12 @@ Gtk.Window {
 
       LinkButton {
         margin-top: 24;
-        label: "Breakpoint";
+        label: _("Breakpoint");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Breakpoint.html";
       }
 
       LinkButton {
-        label: "Breakpoint Bin";
+        label: _("Breakpoint Bin");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.BreakpointBin.html";
       }
     };

--- a/src/Library/demos/Button/main.blp
+++ b/src/Library/demos/Button/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Button";
+  title: _("Button");
   description: _("Allow people to perform actions by clicking");
 
   Box {

--- a/src/Library/demos/Button/main.blp
+++ b/src/Library/demos/Button/main.blp
@@ -14,13 +14,13 @@ Adw.StatusPage {
 
       Button regular {
         name: "regular";
-        label: "Regular";
+        label: _("Regular");
         margin-end: 40;
       }
 
       Button flat {
         name: "flat";
-        label: "Flat";
+        label: _("Flat");
         margin-end: 40;
 
         styles [
@@ -30,7 +30,7 @@ Adw.StatusPage {
 
       Button suggested {
         name: "suggested";
-        label: "Suggested";
+        label: _("Suggested");
 
         styles [
           "suggested-action",
@@ -43,7 +43,7 @@ Adw.StatusPage {
 
       Button destructive {
         name: "destructive";
-        label: "Destructive";
+        label: _("Destructive");
         margin-end: 40;
 
         styles [
@@ -53,13 +53,13 @@ Adw.StatusPage {
 
       Button custom {
         name: "custom";
-        label: "Custom";
+        label: _("Custom");
         margin-end: 40;
       }
 
       Button disabled {
         name: "disabled";
-        label: "Disabled";
+        label: _("Disabled");
         sensitive: false;
       }
     }
@@ -95,7 +95,7 @@ Adw.StatusPage {
 
       Button pill {
         name: "pill";
-        label: "Pill";
+        label: _("Pill");
         margin-end: 60;
 
         styles [
@@ -127,17 +127,17 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "Tutorial";
+      label: _("Tutorial");
       uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/button.html";
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Button.html";
     }
 
     LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/buttons.html";
     }
   }

--- a/src/Library/demos/CSS Gradients/main.blp
+++ b/src/Library/demos/CSS Gradients/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 using GtkSource 5;
 
 Adw.StatusPage {
-  title: "CSS Gradients";
+  title: _("CSS Gradients");
   description: _("Generate an image that smoothly fades from one color to another.");
 
   Box {

--- a/src/Library/demos/Calendar/main.blp
+++ b/src/Library/demos/Calendar/main.blp
@@ -18,7 +18,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Calendar.html";
     }
   }

--- a/src/Library/demos/Calendar/main.blp
+++ b/src/Library/demos/Calendar/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Calendar";
+  title: _("Calendar");
   description: "Display a Gregorian calendar, one month at a time";
 
   Box {

--- a/src/Library/demos/Camera/main.blp
+++ b/src/Library/demos/Camera/main.blp
@@ -24,7 +24,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/method.Portal.access_camera.html";
     }
   }

--- a/src/Library/demos/Carousel/main.blp
+++ b/src/Library/demos/Carousel/main.blp
@@ -20,7 +20,7 @@ Box root_box {
 			icon-name: "carousel-symbolic";
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Carousel.html";
         margin-top: 12;
       }

--- a/src/Library/demos/Checkboxes/main.blp
+++ b/src/Library/demos/Checkboxes/main.blp
@@ -37,11 +37,11 @@ Adw.StatusPage {
       orientation: vertical;
       margin-top: 48;
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/controls/checkboxes.html";
       }
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.CheckButton.html";
       }
     }

--- a/src/Library/demos/Clamp/main.blp
+++ b/src/Library/demos/Clamp/main.blp
@@ -25,7 +25,7 @@ Adw.StatusPage {
 
     LinkButton {
       margin-top: 12;
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Clamp.html";
     }
 

--- a/src/Library/demos/Clamp/main.blp
+++ b/src/Library/demos/Clamp/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Clamp";
+  title: _("Clamp");
   description: "A widget constraining its child to a given size.";
 
   Box {

--- a/src/Library/demos/Color Dialog/main.blp
+++ b/src/Library/demos/Color Dialog/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Color Dialog";
+  title: _("Color Dialog");
   description: _("Show a dialog to select a color");
 
   Box {

--- a/src/Library/demos/Color Dialog/main.blp
+++ b/src/Library/demos/Color Dialog/main.blp
@@ -26,7 +26,7 @@ Adw.StatusPage {
 
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.ColorDialogButton.html";
       }
     }
@@ -49,7 +49,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.ColorDialog.html";
       }
     }

--- a/src/Library/demos/Color Picker/main.blp
+++ b/src/Library/demos/Color Picker/main.blp
@@ -18,7 +18,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/method.Portal.pick_color.html";
     }
   }

--- a/src/Library/demos/Dialogs/main.blp
+++ b/src/Library/demos/Dialogs/main.blp
@@ -10,30 +10,30 @@ Adw.StatusPage {
     halign: center;
 
     Button button_confirmation {
-      label: "Confirmation Dialog";
+      label: _("Confirmation Dialog");
       margin-bottom: 30;
       styles ["pill"]
     }
 
      Button button_error {
-      label: "Error Dialog";
+      label: _("Error Dialog");
       margin-bottom: 30;
       styles ["pill"]
     }
 
      Button button_advanced {
-      label: "Advanced Error Dialog";
+      label: _("Advanced Error Dialog");
       margin-bottom: 30;
       styles ["pill"]
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.MessageDialog.html";
     }
 
      LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/feedback/dialogs.html";
     }
   }

--- a/src/Library/demos/Dialogs/main.blp
+++ b/src/Library/demos/Dialogs/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Dialogs";
+  title: _("Dialogs");
   description: _("Present options, choices or information to users");
 
   Box {

--- a/src/Library/demos/Drag and Drop/main.blp
+++ b/src/Library/demos/Drag and Drop/main.blp
@@ -67,7 +67,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/drag-and-drop.html";
       margin-top: 24;
     }

--- a/src/Library/demos/Drawing Area/main.blp
+++ b/src/Library/demos/Drawing Area/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Drawing Area";
+  title: _("Drawing Area");
   description: _("Programmatically draw onto a surface.");
 
  Box {

--- a/src/Library/demos/Drawing Area/main.blp
+++ b/src/Library/demos/Drawing Area/main.blp
@@ -26,7 +26,7 @@ Adw.StatusPage {
 
     LinkButton {
       margin-top: 48;
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.DrawingArea.html";
     }
   }

--- a/src/Library/demos/Drop Down/main.blp
+++ b/src/Library/demos/Drop Down/main.blp
@@ -36,13 +36,13 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.DropDown.html";
       margin-top: 12;
     }
 
     LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/drop-downs.html";
       margin-top: 12;
     }

--- a/src/Library/demos/Drop Zone/main.blp
+++ b/src/Library/demos/Drop Zone/main.blp
@@ -36,7 +36,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "DropTarget API Reference";
+        label: _("DropTarget API Reference");
         uri: "https://docs.gtk.org/gtk4/class.DropTarget.html";
       }
     }

--- a/src/Library/demos/Drop Zone/main.blp
+++ b/src/Library/demos/Drop Zone/main.blp
@@ -36,7 +36,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: _("DropTarget API Reference");
+        label: _("Drop Target API Reference");
         uri: "https://docs.gtk.org/gtk4/class.DropTarget.html";
       }
     }

--- a/src/Library/demos/Editable Label/main.blp
+++ b/src/Library/demos/Editable Label/main.blp
@@ -21,7 +21,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.EditableLabel.html";
       margin-top: 12;
     }

--- a/src/Library/demos/Email/main.blp
+++ b/src/Library/demos/Email/main.blp
@@ -23,7 +23,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/method.Portal.compose_email.html";
     }
   }

--- a/src/Library/demos/Emoji Chooser/main.blp
+++ b/src/Library/demos/Emoji Chooser/main.blp
@@ -18,7 +18,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.EmojiChooser.html";
     }
   }

--- a/src/Library/demos/Event Controllers/main.blp
+++ b/src/Library/demos/Event Controllers/main.blp
@@ -119,17 +119,17 @@ Adw.StatusPage page {
       margin-top: 24;
 
       LinkButton {
-        label: _("EventControllerKey");
+        label: _("Event Controller Key API Reference");
         uri: "https://docs.gtk.org/gtk4/class.EventControllerKey.html";
       }
 
       LinkButton {
-        label: _("GestureClick");
+        label: _("Gesture Click API Reference");
         uri: "https://docs.gtk.org/gtk4/class.GestureClick.html";
       }
 
       LinkButton {
-        label: _("GestureSwipe");
+        label: _("Gesture Swipe API Reference");
         uri: "https://docs.gtk.org/gtk4/class.GestureSwipe.html";
       }
     }

--- a/src/Library/demos/Event Controllers/main.blp
+++ b/src/Library/demos/Event Controllers/main.blp
@@ -119,17 +119,17 @@ Adw.StatusPage page {
       margin-top: 24;
 
       LinkButton {
-        label: "EventControllerKey";
+        label: _("EventControllerKey");
         uri: "https://docs.gtk.org/gtk4/class.EventControllerKey.html";
       }
 
       LinkButton {
-        label: "GestureClick";
+        label: _("GestureClick");
         uri: "https://docs.gtk.org/gtk4/class.GestureClick.html";
       }
 
       LinkButton {
-        label: "GestureSwipe";
+        label: _("GestureSwipe");
         uri: "https://docs.gtk.org/gtk4/class.GestureSwipe.html";
       }
     }

--- a/src/Library/demos/Flow Box/main.blp
+++ b/src/Library/demos/Flow Box/main.blp
@@ -30,7 +30,7 @@ Gtk.Window {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.FlowBox.html";
       }
     }

--- a/src/Library/demos/Font Dialog/main.blp
+++ b/src/Library/demos/Font Dialog/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Font Dialog";
+  title: _("Font Dialog");
   description: _("Show a dialog to select a font");
 
   Box {

--- a/src/Library/demos/Frame/main.blp
+++ b/src/Library/demos/Frame/main.blp
@@ -189,7 +189,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Frame.html";
     }
   }

--- a/src/Library/demos/Grid/main.blp
+++ b/src/Library/demos/Grid/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Grid";
+  title: _("Grid");
   description: _("Arrange widgets in rows and columns.");
 
  Box {

--- a/src/Library/demos/HTTP Image/main.blp
+++ b/src/Library/demos/HTTP Image/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "HTTP Image";
+  title: _("HTTP Image");
   description: _("Load and display an image from an HTTP URL.");
   valign: start;
 

--- a/src/Library/demos/Header Bar/main.blp
+++ b/src/Library/demos/Header Bar/main.blp
@@ -30,7 +30,7 @@ Gtk.Window {
   };
 
   Adw.StatusPage {
-      title: "Header Bar";
+      title: _("Header Bar");
       description: _("Custom titlebars for windows");
 
       Box{

--- a/src/Library/demos/Header Bar/main.blp
+++ b/src/Library/demos/Header Bar/main.blp
@@ -37,12 +37,12 @@ Gtk.Window {
         orientation:vertical;
 
         LinkButton {
-          label: "API Reference";
+          label: _("API Reference");
           uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.HeaderBar.html";
         }
 
         LinkButton {
-          label: "Human Interface Guidelines";
+          label: _("Human Interface Guidelines");
           uri: "https://developer.gnome.org/hig/patterns/containers/header-bars.html";
         }
       }

--- a/src/Library/demos/Image/main.blp
+++ b/src/Library/demos/Image/main.blp
@@ -87,12 +87,12 @@ Adw.StatusPage {
 
       LinkButton {
         uri: "https://docs.gtk.org/gtk4/class.Image.html";
-        label: "API Reference";
+        label: _("API Reference");
       }
 
       LinkButton {
         uri: "https://developer.gnome.org/hig/guidelines/ui-icons.html";
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
       }
     }
   }

--- a/src/Library/demos/Label/main.blp
+++ b/src/Library/demos/Label/main.blp
@@ -86,7 +86,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Label.html";
     }
 

--- a/src/Library/demos/Level Bars/main.blp
+++ b/src/Library/demos/Level Bars/main.blp
@@ -68,12 +68,12 @@ Adw.StatusPage {
       margin-bottom: 24;
 
       LinkButton {
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/level_bar.html";
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.LevelBar.html";
       }
     }

--- a/src/Library/demos/Link Button/main.blp
+++ b/src/Library/demos/Link Button/main.blp
@@ -6,7 +6,7 @@ Adw.StatusPage {
   description: _("A button with a hyperlink");
 
   LinkButton linkbutton{
-    label: _("Documentation");
+    label: _("API Reference");
     uri: "https://docs.gtk.org/gtk4/class.LinkButton.html";
   }
 }

--- a/src/Library/demos/Link Button/main.blp
+++ b/src/Library/demos/Link Button/main.blp
@@ -6,7 +6,7 @@ Adw.StatusPage {
   description: _("A button with a hyperlink");
 
   LinkButton linkbutton{
-    label: "Documentation";
+    label: _("Documentation");
     uri: "https://docs.gtk.org/gtk4/class.LinkButton.html";
   }
 }

--- a/src/Library/demos/List Model/main.blp
+++ b/src/Library/demos/List Model/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "List Model";
+  title: _("List Model");
   description: _("List models are a simple interface for ordered lists of GObject instances");
   valign: start;
 

--- a/src/Library/demos/List Model/main.blp
+++ b/src/Library/demos/List Model/main.blp
@@ -13,7 +13,7 @@ Adw.StatusPage {
       spacing: 24;
 
       LinkButton {
-        label: "Documentation";
+        label: _("Documentation");
         uri: "https://gjs.guide/guides/gio/list-models.html";
       }
 

--- a/src/Library/demos/List View Widgets/main.blp
+++ b/src/Library/demos/List View Widgets/main.blp
@@ -21,11 +21,11 @@ Adw.StatusPage {
         orientation: horizontal;
         halign: center;
         LinkButton {
-          label: _("List View");
+          label: _("List View API Reference");
           uri: "https://docs.gtk.org/gtk4/class.ListView.html";
         }
         LinkButton {
-          label: _("Grid View");
+          label: _("Grid View API Reference");
           uri: "https://docs.gtk.org/gtk4/class.GridView.html";
         }
       }

--- a/src/Library/demos/Location/main.blp
+++ b/src/Library/demos/Location/main.blp
@@ -165,7 +165,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://libportal.org/method.Portal.location_monitor_start.html";
       }
     }

--- a/src/Library/demos/Map/main.blp
+++ b/src/Library/demos/Map/main.blp
@@ -61,7 +61,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://gnome.pages.gitlab.gnome.org/libshumate/index.html";
       }
     }

--- a/src/Library/demos/Memory Monitor/main.blp
+++ b/src/Library/demos/Memory Monitor/main.blp
@@ -6,7 +6,7 @@ Adw.StatusPage {
   description: _("Monitor system memory");
 
   LinkButton {
-    label: "API Reference";
+    label: _("API Reference");
     uri: "https://docs.gtk.org/gio/iface.MemoryMonitor.html";
   }
 }

--- a/src/Library/demos/Menu Button/main.blp
+++ b/src/Library/demos/Menu Button/main.blp
@@ -68,12 +68,12 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
          uri: "https://developer.gnome.org/hig/patterns/controls/menus.html";
       }
 
       LinkButton {
-        label: "Menu Button API Reference";
+        label: _("Menu Button API Reference");
          uri: "https://docs.gtk.org/gtk4/class.MenuButton.html";
       }
     }

--- a/src/Library/demos/Menu/main.blp
+++ b/src/Library/demos/Menu/main.blp
@@ -51,12 +51,12 @@ Adw.StatusPage demo {
         halign: center;
 
         LinkButton {
-          label: "GJS Guide";
+          label: _("GJS Guide");
           uri: "https://gjs.guide/guides/gio/actions-and-menus.html#gmenu";
         }
 
         LinkButton {
-          label: "Human Interface Guidelines";
+          label: _("Human Interface Guidelines");
           uri: "https://developer.gnome.org/hig/patterns/controls/menus.html";
         }
       }

--- a/src/Library/demos/Navigation Split View/main.blp
+++ b/src/Library/demos/Navigation Split View/main.blp
@@ -17,7 +17,7 @@ Adw.Window {
 
   content: Adw.NavigationSplitView split_view {
     sidebar: Adw.NavigationPage {
-      title: "Sidebar";
+      title: _("Sidebar");
       tag: "sidebar";
       child: Adw.ToolbarView {
 
@@ -43,7 +43,7 @@ Adw.Window {
     };
 
     content: Adw.NavigationPage {
-      title: "Content";
+      title: _("Content");
       tag: "content";
       child: Adw.ToolbarView {
 

--- a/src/Library/demos/Navigation Split View/main.blp
+++ b/src/Library/demos/Navigation Split View/main.blp
@@ -56,7 +56,7 @@ Adw.Window {
           title: _("Content");
 
           LinkButton {
-            label: "API Reference";
+            label: _("API Reference");
             uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.NavigationSplitView.html";
           }
         };

--- a/src/Library/demos/Network Monitor/main.blp
+++ b/src/Library/demos/Network Monitor/main.blp
@@ -165,7 +165,7 @@ Box {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gio/iface.NetworkMonitor.html";
       }
     }

--- a/src/Library/demos/Notification/main.blp
+++ b/src/Library/demos/Notification/main.blp
@@ -10,23 +10,23 @@ Adw.StatusPage {
     halign: center;
 
     Button button_simple {
-      label: "Trigger notification";
+      label: _("Trigger notification");
       margin-bottom: 30;
       styles ["pill"]
     }
 
     LinkButton {
-      label: "Tutorial";
+      label: _("Tutorial");
       uri: "https://developer.gnome.org/documentation/tutorials/notifications.html";
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gio/class.Notification.html";
     }
 
     LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/feedback/notifications.html";
     }
   }

--- a/src/Library/demos/Notification/main.blp
+++ b/src/Library/demos/Notification/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Notification";
+  title: _("Notification");
   description: "Desktop notifications";
 
   Box {

--- a/src/Library/demos/Notification/main.blp
+++ b/src/Library/demos/Notification/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Adw.StatusPage {
   title: _("Notification");
-  description: "Desktop notifications";
+  description: _("Desktop notifications");
 
   Box {
     orientation: vertical;

--- a/src/Library/demos/Overlay Split View/main.blp
+++ b/src/Library/demos/Overlay Split View/main.blp
@@ -74,7 +74,7 @@ Adw.Window {
           spacing: 18;
 
           LinkButton {
-            label: "API Reference";
+            label: _("API Reference");
             uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.OverlaySplitView.html";
             margin-top: 24;
           }

--- a/src/Library/demos/Overlay/main.blp
+++ b/src/Library/demos/Overlay/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Adw.StatusPage {
   title: _("Overlay");
-  description: "Overlay widgets on top of a each other";
+  description: _("Overlay widgets on top of a each other");
 
   Adw.Clamp{
     Overlay {

--- a/src/Library/demos/Overlay/main.blp
+++ b/src/Library/demos/Overlay/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Overlay";
+  title: _("Overlay");
   description: "Overlay widgets on top of a each other";
 
   Adw.Clamp{

--- a/src/Library/demos/Platform Tools/main.blp
+++ b/src/Library/demos/Platform Tools/main.blp
@@ -12,7 +12,7 @@ Adw.StatusPage {
       halign: center;
 
       Button adwaita-1-demo {
-        label: "Adwaita Demo";
+        label: _("Adwaita Demo");
         action-name: "app.platform_tools";
         action-target: "'adwaita-1-demo'";
         styles ["pill"]
@@ -25,7 +25,7 @@ Adw.StatusPage {
       }
 
       Button gtk4-demo {
-        label: "GTK Demo";
+        label: _("GTK Demo");
         action-name: "app.platform_tools";
         action-target: "'gtk4-demo'";
         styles ["pill"]
@@ -38,7 +38,7 @@ Adw.StatusPage {
       }
 
       Button gtk4-widget-factory {
-        label: "GTK Widget Factory";
+        label: _("GTK Widget Factory");
         action-name: "app.platform_tools";
         action-target: "'gtk4-widget-factory'";
         styles ["pill"]
@@ -67,7 +67,7 @@ Adw.StatusPage {
       LinkButton {
         margin-top: 6;
         halign: center;
-        label: "The GTK Inspector";
+        label: _("The GTK Inspector");
         // https://gitlab.gnome.org/Teams/documentation/developer-www/-/issues/40
         uri: "https://blog.gtk.org/2017/04/05/the-gtk-inspector/";
       }

--- a/src/Library/demos/Platform Tools/main.blp
+++ b/src/Library/demos/Platform Tools/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Platform Tools";
+  title: _("Platform Tools");
 
   Box {
     orientation: vertical;

--- a/src/Library/demos/Popovers/main.blp
+++ b/src/Library/demos/Popovers/main.blp
@@ -26,12 +26,12 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: _("Popover");
+      label: _("Popover API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Popover.html";
     }
 
     LinkButton {
-      label: _("Popover Menu");
+      label: _("Popover Menu API Reference");
       uri: "https://docs.gtk.org/gtk4/class.PopoverMenu.html";
     }
 

--- a/src/Library/demos/Popovers/main.blp
+++ b/src/Library/demos/Popovers/main.blp
@@ -15,29 +15,29 @@ Adw.StatusPage {
       halign: center;
 
       MenuButton {
-        label: "Plain Popover";
+        label: _("Plain Popover");
         popover: plain_popover;
       }
 
       MenuButton {
-        label: "Popover Menu";
+        label: _("Popover Menu");
         popover: popover_menu;
       }
     }
 
     LinkButton {
-      label: "Popover";
+      label: _("Popover");
       uri: "https://docs.gtk.org/gtk4/class.Popover.html";
     }
 
     LinkButton {
-      label: "Popover Menu";
+      label: _("Popover Menu");
       uri: "https://docs.gtk.org/gtk4/class.PopoverMenu.html";
     }
 
     LinkButton {
       margin-top: 24;
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/containers/popovers.html";
     }
   }
@@ -50,7 +50,7 @@ Popover plain_popover {
     name: "plain-popover-box";
 
     Label {
-      label: "Plain Popover";
+      label: _("Plain Popover");
     }
   };
 }

--- a/src/Library/demos/Popovers/main.blp
+++ b/src/Library/demos/Popovers/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Popovers";
+  title: _("Popovers");
   description: _("Display content in a container anchored to another widget");
 
   Box {

--- a/src/Library/demos/Power Profile Monitor/main.blp
+++ b/src/Library/demos/Power Profile Monitor/main.blp
@@ -24,7 +24,7 @@ Adw.ToastOverlay overlay {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gio/iface.PowerProfileMonitor.html";
       }
     }

--- a/src/Library/demos/Progress Bar/main.blp
+++ b/src/Library/demos/Progress Bar/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Progress Bar";
+  title: _("Progress Bar");
   description: _("Display the progress of a long running operation");
 
   Box {

--- a/src/Library/demos/Progress Bar/main.blp
+++ b/src/Library/demos/Progress Bar/main.blp
@@ -35,12 +35,12 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.ProgressBar.html";
         }
 
       LinkButton{
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/feedback/progress-bars.html";
         }
     }

--- a/src/Library/demos/Radio Buttons/main.blp
+++ b/src/Library/demos/Radio Buttons/main.blp
@@ -40,11 +40,11 @@ Adw.StatusPage {
       orientation: vertical;
       margin-top: 48;
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/controls/radio-buttons.html";
       }
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.CheckButton.html";
       }
     }

--- a/src/Library/demos/Revealer/main.blp
+++ b/src/Library/demos/Revealer/main.blp
@@ -87,7 +87,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Revealer.html";
     }
   }

--- a/src/Library/demos/Scale/main.blp
+++ b/src/Library/demos/Scale/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Scale";
+  title: _("Scale");
   description: _("Slider control to select a value from a range");
 
   Box {

--- a/src/Library/demos/Scale/main.blp
+++ b/src/Library/demos/Scale/main.blp
@@ -61,17 +61,17 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "Scale API Reference";
+      label: _("Scale API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Scale.html";
     }
 
     LinkButton {
-      label: "ScaleButton API Reference";
+      label: _("ScaleButton API Reference");
       uri: "https://docs.gtk.org/gtk4/class.ScaleButton.html";
     }
 
     LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/sliders.html";
     }
   }

--- a/src/Library/demos/Screencast/main.blp
+++ b/src/Library/demos/Screencast/main.blp
@@ -24,7 +24,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/class.Session.html";
     }
   }

--- a/src/Library/demos/Screencast/main.blp
+++ b/src/Library/demos/Screencast/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Screencast";
+  title: _("Screencast");
   description: _("Capture your desktop");
   margin-top: 48;
 

--- a/src/Library/demos/Screenshot/main.blp
+++ b/src/Library/demos/Screenshot/main.blp
@@ -25,7 +25,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/method.Portal.take_screenshot.html";
     }
   }

--- a/src/Library/demos/Screenshot/main.blp
+++ b/src/Library/demos/Screenshot/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Screenshot";
+  title: _("Screenshot");
   description: _("Take a picture of the screen");
   margin-top: 48;
 

--- a/src/Library/demos/Scrolled Window/main.blp
+++ b/src/Library/demos/Scrolled Window/main.blp
@@ -68,7 +68,7 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.ScrolledWindow.html";
       }
     }

--- a/src/Library/demos/Search/main.blp
+++ b/src/Library/demos/Search/main.blp
@@ -43,11 +43,11 @@ Adw.Window {
           Box{
             halign: center;
             LinkButton {
-              label: _("Search Entry");
+              label: _("Search Entry API Reference");
               uri: "https://docs.gtk.org/gtk4/class.SearchEntry.html";
             }
             LinkButton {
-              label: _("Search Bar");
+              label: _("Search Bar API Reference");
               uri: "https://docs.gtk.org/gtk4/class.SearchBar";
             }
           }

--- a/src/Library/demos/Separator/main.blp
+++ b/src/Library/demos/Separator/main.blp
@@ -66,7 +66,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Separator.html";
     }
   }

--- a/src/Library/demos/Session Monitor and Inhibit/main.blp
+++ b/src/Library/demos/Session Monitor and Inhibit/main.blp
@@ -64,12 +64,12 @@ Adw.StatusPage {
 
         Box {
           LinkButton {
-            label: "Session Monitor";
+            label: _("Session Monitor");
             uri: "https://libportal.org/method.Portal.session_monitor_start.html";
           }
 
           LinkButton {
-            label: "Session Inhibit";
+            label: _("Session Inhibit");
             uri: "https://libportal.org/method.Portal.session_inhibit.html";
           }
         }

--- a/src/Library/demos/Source View/main.blp
+++ b/src/Library/demos/Source View/main.blp
@@ -17,7 +17,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://gnome.pages.gitlab.gnome.org/gtksourceview/gtksourceview5/class.View.html";
     }
   }

--- a/src/Library/demos/Source View/main.blp
+++ b/src/Library/demos/Source View/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 using GtkSource 5;
 
 Adw.StatusPage {
-  title: "Source View";
+  title: _("Source View");
   description: _("Widget that enables text-editing with advanced features like syntax highlighting");
 
   Box {

--- a/src/Library/demos/Spin Button/main.blp
+++ b/src/Library/demos/Spin Button/main.blp
@@ -53,17 +53,17 @@ Adw.StatusPage {
       orientation: vertical;
 
       LinkButton {
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/spin_button.html";
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.SpinButton.html";
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/controls/spin-buttons.html";
       }
     }

--- a/src/Library/demos/Spinner/main.blp
+++ b/src/Library/demos/Spinner/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Spinner";
+  title: _("Spinner");
   description: _("Display loading state");
 
   Box {

--- a/src/Library/demos/Spinner/main.blp
+++ b/src/Library/demos/Spinner/main.blp
@@ -22,17 +22,17 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "Tutorial";
+      label: _("Tutorial");
       uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/spinner.html";
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Spinner.html";
     }
 
     LinkButton {
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/feedback/spinners.html";
     }
   }

--- a/src/Library/demos/Stack/main.blp
+++ b/src/Library/demos/Stack/main.blp
@@ -28,17 +28,17 @@ Box root_box {
           margin-top: 24;
 
           LinkButton {
-            label: _("Stack");
+            label: _("Stack API Reference");
             uri: "https://docs.gtk.org/gtk4/class.Stack.html";
           }
 
           LinkButton {
-            label: _("Stack Sidebar");
+            label: _("Stack Sidebar API Reference");
             uri: "https://docs.gtk.org/gtk4/class.StackSidebar.html";
           }
 
           LinkButton {
-            label: _("Stack Switcher");
+            label: _("Stack Switcher API Reference");
             uri: "https://docs.gtk.org/gtk4/class.StackSwitcher.html";
           }
         }

--- a/src/Library/demos/Status Page/main.blp
+++ b/src/Library/demos/Status Page/main.blp
@@ -14,11 +14,11 @@ Box child {
   halign: center;
 
   LinkButton {
-    label: "API Reference";
+    label: _("API Reference");
     uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.StatusPage.html";
   }
   LinkButton {
-    label: "Human Interface Guidelines";
+    label: _("Human Interface Guidelines");
     uri: "https://developer.gnome.org/hig/patterns/feedback/placeholders.html";
   }
 }

--- a/src/Library/demos/Styling with CSS/main.blp
+++ b/src/Library/demos/Styling with CSS/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Adw.StatusPage {
   title: _("Styling with CSS");
-  description: "Change the appearence of widgets";
+  description: _("Change the appearence of widgets");
 
   Box {
     orientation: vertical;

--- a/src/Library/demos/Styling with CSS/main.blp
+++ b/src/Library/demos/Styling with CSS/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Styling with CSS";
+  title: _("Styling with CSS");
   description: "Change the appearence of widgets";
 
   Box {

--- a/src/Library/demos/Switch/main.blp
+++ b/src/Library/demos/Switch/main.blp
@@ -15,7 +15,7 @@ Adw.StatusPage {
     }
 
     Label label_on {
-      label: "On";
+      label: _("On");
       margin-bottom: 30;
     }
 
@@ -26,7 +26,7 @@ Adw.StatusPage {
     }
 
     Label label_off {
-      label: "Off";
+      label: _("Off");
       margin-bottom: 30;
     }
 
@@ -37,22 +37,22 @@ Adw.StatusPage {
     }
 
     Label {
-      label: "Disabled";
+      label: _("Disabled");
       margin-bottom: 30;
     }
 
     LinkButton{
-      label: "Tutorial";
+      label: _("Tutorial");
       uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/switch.html";
     }
 
     LinkButton{
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Switch.html";
     }
 
     LinkButton{
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/switches.html";
     }
   }

--- a/src/Library/demos/Switch/main.blp
+++ b/src/Library/demos/Switch/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Switch";
+  title: _("Switch");
   description: _("A simple on/off control");
 
   Box {

--- a/src/Library/demos/Tab View/main.blp
+++ b/src/Library/demos/Tab View/main.blp
@@ -40,20 +40,20 @@ Adw.Window {
               Box{
                 halign: center;
                 LinkButton {
-                  label: "Tab View";
+                  label: _("Tab View");
                   uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.TabView.html";
                 }
                 LinkButton {
-                  label: "Tab Bar";
+                  label: _("Tab Bar");
                   uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.TabBar.html";
                 }
                 LinkButton {
-                  label: "Tab Overview";
+                  label: _("Tab Overview");
                   uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.TabOverview.html";
                 }
               }
               LinkButton {
-                label: "Human Interface Guidelines";
+                label: _("Human Interface Guidelines");
                 uri: "https://developer.gnome.org/hig/patterns/nav/tabs.html";
               }
             }

--- a/src/Library/demos/Text Colors/main.blp
+++ b/src/Library/demos/Text Colors/main.blp
@@ -15,7 +15,7 @@ Box main {
   }
 
   Label {
-    label: "Colored with Pango attributes";
+    label: _("Colored with Pango attributes");
   }
 
   Entry entry {

--- a/src/Library/demos/Text Fields/main.blp
+++ b/src/Library/demos/Text Fields/main.blp
@@ -90,9 +90,9 @@ Adw.Clamp {
         Entry entry_icon {
           primary-icon-name: "about-symbolic";
           primary-icon-activatable: true;
-          primary-icon-tooltip-text: "Click on Me";
+          primary-icon-tooltip-text: _("Click on Me");
           secondary-icon-name: "bell-symbolic";
-          secondary-icon-tooltip-text: "No Click on Me";
+          secondary-icon-tooltip-text: _("No Click on Me");
         }
       }
 
@@ -108,7 +108,7 @@ Adw.Clamp {
           Entry entry_progress {
             progress-fraction: 0;
             primary-icon-name: "media-playback-start-symbolic";
-            primary-icon-tooltip-text: "Play Animation";
+            primary-icon-tooltip-text: _("Play Animation");
           }
         }
       }

--- a/src/Library/demos/Text Fields/main.blp
+++ b/src/Library/demos/Text Fields/main.blp
@@ -6,7 +6,7 @@ Adw.Clamp {
     orientation: vertical;
 
     Label {
-      label: "Text Fields";
+      label: _("Text Fields");
       margin-top: 12;
       margin-bottom: 12;
 
@@ -16,18 +16,18 @@ Adw.Clamp {
     }
 
     Label {
-      label: "Single line widgets to enter text";
+      label: _("Single line widgets to enter text");
       margin-bottom: 12;
     }
 
     LinkButton{
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/text-fields.html";
       margin-bottom: 6;
     }
 
     Label {
-      label: "Entry";
+      label: _("Entry");
       margin-top: 12;
       halign: start;
 
@@ -56,7 +56,7 @@ Adw.Clamp {
         orientation: vertical;
 
         Label {
-          label: "Regular";
+          label: _("Regular");
           margin-bottom: 12;
         }
 
@@ -70,7 +70,7 @@ Adw.Clamp {
         orientation: vertical;
 
         Label {
-          label: "Placeholder Text";
+          label: _("Placeholder Text");
           margin-bottom: 12;
         }
 
@@ -83,7 +83,7 @@ Adw.Clamp {
         orientation: vertical;
 
         Label {
-          label: "Icons";
+          label: _("Icons");
           margin-bottom: 12;
         }
 
@@ -100,7 +100,7 @@ Adw.Clamp {
           orientation: vertical;
 
           Label {
-            label: "Progress Bar";
+            label: _("Progress Bar");
             margin-bottom: 12;
 
           }
@@ -119,12 +119,12 @@ Adw.Clamp {
       margin-bottom: 18;
 
       LinkButton{
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/entry.html";
       }
 
       LinkButton{
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.Entry.html";
       }
     }
@@ -134,7 +134,7 @@ Adw.Clamp {
     }
 
     Label {
-      label: "Completion Entry";
+      label: _("Completion Entry");
       halign: start;
 
       styles [
@@ -160,7 +160,7 @@ Adw.Clamp {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.EntryCompletion.html";
       margin-top: 18;
       margin-bottom: 18;
@@ -171,7 +171,7 @@ Adw.Clamp {
     }
 
     Label {
-      label: "Password Entry";
+      label: _("Password Entry");
       halign: start;
 
       styles [
@@ -211,12 +211,12 @@ Adw.Clamp {
       margin-bottom: 18;
 
       LinkButton{
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/password_entry.html";
       }
 
       LinkButton{
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.PasswordEntry.html";
       }
     }
@@ -226,7 +226,7 @@ Adw.Clamp {
     }
 
     Label {
-      label: "Style Classes";
+      label: _("Style Classes");
       margin-bottom: 12;
       halign: start;
 

--- a/src/Library/demos/Text View/main.blp
+++ b/src/Library/demos/Text View/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Text View";
+  title: _("Text View");
   description: _("A widget that enables text-editing");
 
   Box {

--- a/src/Library/demos/Text View/main.blp
+++ b/src/Library/demos/Text View/main.blp
@@ -66,7 +66,7 @@ Adw.StatusPage {
     }
 
     LinkButton{
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.TextView.html";
     }
   }

--- a/src/Library/demos/Toasts/main.blp
+++ b/src/Library/demos/Toasts/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Adw.ToastOverlay overlay {
   Adw.StatusPage {
-    title: "Toasts";
+    title: _("Toasts");
     description: "In-app notifications";
 
     Box {

--- a/src/Library/demos/Toasts/main.blp
+++ b/src/Library/demos/Toasts/main.blp
@@ -11,29 +11,29 @@ Adw.ToastOverlay overlay {
       halign: center;
 
       Button button_simple {
-        label: "Simple";
+        label: _("Simple");
         margin-bottom: 30;
         styles ["pill"]
       }
 
       Button button_advanced {
-        label: "Advanced";
+        label: _("Advanced");
         margin-bottom: 30;
         styles ["pill"]
       }
 
       LinkButton {
-        label: "Tutorial";
+        label: _("Tutorial");
         uri: "https://developer.gnome.org/documentation/tutorials/beginners/getting_started/adding_toasts.html";
       }
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.Toast.html";
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/feedback/toasts.html";
       }
     }

--- a/src/Library/demos/Toggle Button/main.blp
+++ b/src/Library/demos/Toggle Button/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "Toggle Button";
+  title: _("Toggle Button");
   description: _("Represent active-state visually");
 
   Box {

--- a/src/Library/demos/Toggle Button/main.blp
+++ b/src/Library/demos/Toggle Button/main.blp
@@ -27,7 +27,7 @@ Adw.StatusPage {
     }
 
     Label {
-      label: "Grouped";
+      label: _("Grouped");
       margin-bottom: 24;
     }
 
@@ -51,7 +51,7 @@ Adw.StatusPage {
     }
 
     Label {
-      label: "Independent";
+      label: _("Independent");
       margin-bottom: 24;
     }
 
@@ -62,28 +62,28 @@ Adw.StatusPage {
       Adw.ButtonContent {
         halign: center;
         valign: center;
-        label: "Console";
+        label: _("Console");
         icon-name: "terminal-symbolic";
       }
     }
 
     Label {
-      label: "With label";
+      label: _("With label");
       margin-bottom: 24;
     }
 
     LinkButton{
-      label: "Tutorial";
+      label: _("Tutorial");
       uri: "https://developer.gnome.org/documentation/tutorials/beginners/components/toggle.html";
     }
 
     LinkButton{
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.ToggleButton.html";
     }
 
     LinkButton{
-      label: "Human Interface Guidelines";
+      label: _("Human Interface Guidelines");
       uri: "https://developer.gnome.org/hig/patterns/controls/buttons.html";
     }
   }

--- a/src/Library/demos/Tooltip/main.blp
+++ b/src/Library/demos/Tooltip/main.blp
@@ -57,12 +57,12 @@ Adw.StatusPage {
       orientation: vertical;
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://docs.gtk.org/gtk4/class.Tooltip.html";
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/feedback/tooltips";
       }
     }

--- a/src/Library/demos/Video/main.blp
+++ b/src/Library/demos/Video/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage page {
-  title: "Video";
+  title: _("Video");
   description: _("Display video with media controls");
 
   Box {

--- a/src/Library/demos/Video/main.blp
+++ b/src/Library/demos/Video/main.blp
@@ -17,7 +17,7 @@ Adw.StatusPage page {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://docs.gtk.org/gtk4/class.Video.html";
       margin-top: 12;
     }

--- a/src/Library/demos/View Switcher/main.blp
+++ b/src/Library/demos/View Switcher/main.blp
@@ -33,11 +33,11 @@ Adw.Window {
             valign: center;
 
             LinkButton {
-              label: "API Reference";
+              label: _("API Reference");
               uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.ViewSwitcher.html";
             }
             LinkButton {
-              label: "Human Interface Guidelines";
+              label: _("Human Interface Guidelines");
               uri: "https://developer.gnome.org/hig/patterns/nav/view-switchers.html";
             }
           };
@@ -59,11 +59,11 @@ Adw.Window {
             valign: center;
 
             LinkButton {
-              label: "API Reference";
+              label: _("API Reference");
               uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.ViewSwitcher.html";
             }
             LinkButton {
-              label: "Human Interface Guidelines";
+              label: _("Human Interface Guidelines");
               uri: "https://developer.gnome.org/hig/patterns/nav/view-switchers.html";
             }
           };
@@ -110,12 +110,12 @@ Adw.Window {
             valign: center;
 
             LinkButton {
-              label: "API Reference";
+              label: _("API Reference");
               uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.ViewSwitcher.html";
             }
 
             LinkButton {
-              label: "Human Interface Guidelines";
+              label: _("Human Interface Guidelines");
               uri: "https://developer.gnome.org/hig/patterns/nav/view-switchers.html";
             }
           };

--- a/src/Library/demos/Wallpaper/main.blp
+++ b/src/Library/demos/Wallpaper/main.blp
@@ -18,7 +18,7 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libportal.org/method.Portal.set_wallpaper.html";
     }
   }

--- a/src/Library/demos/Web View/main.blp
+++ b/src/Library/demos/Web View/main.blp
@@ -15,13 +15,13 @@ Adw.Clamp {
       spacing: 6;
 
       Label {
-        label: "Web View";
+        label: _("Web View");
 
         styles ["title-1"]
       }
 
       Label {
-        label: "Load and display webpages and HTML";
+        label: _("Load and display webpages and HTML");
       }
     }
 
@@ -67,7 +67,7 @@ Adw.Clamp {
 
     LinkButton {
       margin-bottom: 12;
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://webkitgtk.org/reference/webkit2gtk/stable/class.WebView.html";
     }
   }

--- a/src/Library/demos/WebSocket Client/main.blp
+++ b/src/Library/demos/WebSocket Client/main.blp
@@ -16,12 +16,12 @@ Adw.StatusPage {
     }
 
     Button button_connect {
-      label: "Connect";
+      label: _("Connect");
       margin-bottom: 24;
     }
 
     Button button_disconnect {
-      label: "Disconnect";
+      label: _("Disconnect");
       sensitive: false;
       margin-bottom: 24;
     }
@@ -35,7 +35,7 @@ Adw.StatusPage {
       }
 
       Button button_send {
-        label: "Send";
+        label: _("Send");
         sensitive: false;
       }
 
@@ -43,12 +43,12 @@ Adw.StatusPage {
     }
 
     LinkButton {
-      label: "GJS Asynchronous Operations";
+      label: _("GJS Asynchronous Operations");
       uri: "https://gjs.guide/guides/gjs/asynchronous-programming.html#asynchronous-operations";
     }
 
     LinkButton {
-      label: "API Reference";
+      label: _("API Reference");
       uri: "https://libsoup.org/libsoup-3.0/class.WebsocketConnection.html";
     }
   }

--- a/src/Library/demos/WebSocket Client/main.blp
+++ b/src/Library/demos/WebSocket Client/main.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 Adw.StatusPage {
   title: _("WebSocket Client");
-  description: "Connect to a WebSocket server";
+  description: _("Connect to a WebSocket server");
 
   Box {
     orientation: vertical;

--- a/src/Library/demos/WebSocket Client/main.blp
+++ b/src/Library/demos/WebSocket Client/main.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 Adw.StatusPage {
-  title: "WebSocket Client";
+  title: _("WebSocket Client");
   description: "Connect to a WebSocket server";
 
   Box {

--- a/src/Library/demos/Welcome/main.blp
+++ b/src/Library/demos/Welcome/main.blp
@@ -14,7 +14,7 @@ Box welcome {
   }
 
   Label {
-    label: "Welcome to Workbench";
+    label: _("Welcome to Workbench");
     margin-bottom: 30;
     styles ["title-1"]
   }
@@ -41,7 +41,7 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Edit Style or UI to update the Preview";
+        label: _("Edit Style or UI to update the Preview");
       }
     }
 
@@ -53,14 +53,14 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Hit";
+        label: _("Hit");
       }
       ShortcutsShortcut {
         accelerator: "<Control>Return";
         margin-start: 12;
       }
       Label {
-        label: "to format and run Code";
+        label: _("to format and run Code");
       }
     }
 
@@ -72,7 +72,7 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Changes are automatically saved and restored";
+        label: _("Changes are automatically saved and restored");
       }
     }
 
@@ -84,7 +84,7 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Browse the Library for demos and examples";
+        label: _("Browse the Library for demos and examples");
       }
     }
 
@@ -96,7 +96,7 @@ Box welcome {
         icon-size: normal;
       }
       Label {
-        label: "Checkout the Bookmarks menu to learn and get help";
+        label: _("Checkout the Bookmarks menu to learn and get help");
       }
     }
   }

--- a/src/Library/demos/Window/main.blp
+++ b/src/Library/demos/Window/main.blp
@@ -23,12 +23,12 @@ Gtk.Window window {
       orientation: vertical;
 
       LinkButton {
-        label: "API Reference";
+        label: _("API Reference");
         uri: "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.4/class.ApplicationWindow.html";
       }
 
       LinkButton {
-        label: "Human Interface Guidelines";
+        label: _("Human Interface Guidelines");
         uri: "https://developer.gnome.org/hig/patterns/containers/windows.html";
       }
     }

--- a/src/Library/demos/Window/main.blp
+++ b/src/Library/demos/Window/main.blp
@@ -4,7 +4,7 @@ using Adw 1;
 Gtk.Window window {
   default-width: 800;
   default-height: 600;
-  title: "My App";
+  title: _("My App");
   titlebar: Gtk.HeaderBar {
     [end]
     MenuButton button_menu {
@@ -15,7 +15,7 @@ Gtk.Window window {
   };
 
   Adw.StatusPage {
-    title: "My App";
+    title: _("My App");
     description: "My App is awesome";
     icon-name: "applications-science-symbolic";
 

--- a/src/Library/demos/Window/main.blp
+++ b/src/Library/demos/Window/main.blp
@@ -16,7 +16,7 @@ Gtk.Window window {
 
   Adw.StatusPage {
     title: _("My App");
-    description: "My App is awesome";
+    description: _("My App is awesome");
     icon-name: "applications-science-symbolic";
 
     Box {


### PR DESCRIPTION
Purely mechanical search and replace. I didn't test the demos, but I did review all the changes. I searched for:

-  title
- description
- tooltip-text
- label

One think I'm not sure is API reference labels that contain class names. For example **StackSidebar** has label "**Stack Sidebar API Reference**". Should it be like this or should we use the actual class name like "**StackSidebar API Reference**"? Both approaches were used, for now I unified everything to use first approach.
Another example are demos that have class names in labels like "**Box**". For now I set them as translatable, since often the user name and the class name are the same. I think this is the list of such cases, but I'm probably missing some (or a lot :smile: ):

- Breakpoints
- Event Controllers
- Box
- Popovers
- Text Fields
- Toggle Button