### PR TITLE
Library: Use dedicated row widgets it 'Location' demo

### DIFF
--- a/src/Library/demos/Location/main.blp
+++ b/src/Library/demos/Location/main.blp
@@ -35,7 +35,7 @@ Adw.StatusPage {
 
         Adw.SpinRow time_threshold {
           title: _("Time Threshold");
-          subtitle: _("In meters");
+          subtitle: _("In seconds");
           value: 0;
           climb-rate: 1;
           adjustment: Adjustment {

--- a/src/Library/demos/Location/main.blp
+++ b/src/Library/demos/Location/main.blp
@@ -19,40 +19,31 @@ Adw.StatusPage {
 
         styles ["boxed-list"]
 
-        Adw.ActionRow {
+        Adw.SpinRow distance_threshold {
           title: _("Distance Threshold");
           subtitle: _("In meters");
-
-          SpinButton distance_threshold {
-            valign: center;
-            wrap: true;
+          wrap: true;
+          value: 0;
+          climb-rate: 1;
+          adjustment: Adjustment {
+            lower: 0;
+            upper: 100;
+            step-increment: 1;
             value: 0;
-            climb-rate: 1;
-            adjustment: Adjustment {
-              lower: 0;
-              upper: 100;
-              step-increment: 1;
-              value: 0;
-            };
-          }
+          };
         }
 
-        Adw.ActionRow {
+        Adw.SpinRow time_threshold {
           title: _("Time Threshold");
           subtitle: _("In meters");
-
-          SpinButton time_threshold {
-            valign: center;
-            wrap: true;
+          value: 0;
+          climb-rate: 1;
+          adjustment: Adjustment {
+            lower: 0;
+            upper: 100;
+            step-increment: 1;
             value: 0;
-            climb-rate: 1;
-            adjustment: Adjustment {
-                          lower: 0;
-                          upper: 100;
-                          step-increment: 1;
-                          value: 0;
-                        };
-          }
+          };
         }
 
         Adw.ComboRow accuracy_button {
@@ -165,13 +156,9 @@ Adw.StatusPage {
       }
 
       LinkButton {
-        label: _("API Reference");
+        label: "API Reference";
         uri: "https://libportal.org/method.Portal.location_monitor_start.html";
       }
     }
   }
 }
-
-
-
-

--- a/src/Library/demos/Location/main.js
+++ b/src/Library/demos/Location/main.js
@@ -31,7 +31,7 @@ let locationAccuracy = Xdp.LocationAccuracy.Exact;
 let distanceThreshold = distance_threshold.value;
 let timeThreshold = time_threshold.value;
 
-time_threshold.connect("value-changed", () => {
+time_threshold.adjustment.connect("value-changed", () => {
   portal.location_monitor_stop();
   revealer.reveal_child = false;
   timeThreshold = time_threshold.value;
@@ -39,7 +39,7 @@ time_threshold.connect("value-changed", () => {
   startSession();
 });
 
-distance_threshold.connect("value-changed", () => {
+distance_threshold.adjustment.connect("value-changed", () => {
   portal.location_monitor_stop();
   revealer.reveal_child = false;
   distanceThreshold = distance_threshold.value;

--- a/src/Library/demos/Location/main.vala
+++ b/src/Library/demos/Location/main.vala
@@ -6,8 +6,8 @@ private Xdp.Parent parent;
 private Gtk.Revealer revealer;
 private Gtk.Button start_button;
 private Gtk.Button close_button;
-private Gtk.SpinButton distance_threshold;
-private Gtk.SpinButton time_threshold;
+private Gtk.SpinRow distance_threshold;
+private Gtk.SpinRow time_threshold;
 private Adw.ComboRow accuracy_button;
 
 private Gtk.Label latitude_label;
@@ -26,8 +26,8 @@ public void main () {
   revealer = (Gtk.Revealer) workbench.builder.get_object ("revealer");
   start_button = (Gtk.Button) workbench.builder.get_object ("start");
   close_button = (Gtk.Button) workbench.builder.get_object ("close");
-  distance_threshold = (Gtk.SpinButton) workbench.builder.get_object ("distance_threshold");
-  time_threshold = (Gtk.SpinButton) workbench.builder.get_object ("time_threshold");
+  distance_threshold = (Adw.SpinRow) workbench.builder.get_object ("distance_threshold");
+  time_threshold = (Adw.SpinRow) workbench.builder.get_object ("time_threshold");
   accuracy_button = (Adw.ComboRow) workbench.builder.get_object ("accuracy_button");
 
   latitude_label = (Gtk.Label) workbench.builder.get_object ("latitude");
@@ -42,12 +42,12 @@ public void main () {
   start_button.clicked.connect (start_session);
   close_button.clicked.connect (close_session);
 
-  time_threshold.value_changed.connect (() => {
+  time_threshold.adjustment.value_changed.connect (() => {
     message ("Time threshold changed");
     restart_session ();
   });
 
-  distance_threshold.value_changed.connect (() => {
+  distance_threshold.adjustment.value_changed.connect (() => {
     message ("Distance threshold changed");
     restart_session ();
   });


### PR DESCRIPTION
Also fix a copy-paste error in "Time Threshold" subtitle - time is measured in second, not meters.
I tried to update the Vala code for the demo, but it doesn't compile even without my changes:

> main.vala.c:4:10: fatal error: libportal/portal.h: No such file or directory
>     4 | #include <libportal/portal.h>
>       |          ^~~~~~~~~~~~~~~~~~~~
> 

This is on vanilla Workbench 45.0 running from the flatpak.
 
Marked as draft until the Vala issue is resolved