### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -43,7 +43,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="45.1" date="2023-09-29">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Reduce Workbench download size</li>
           <li>Add "Extensions" to enable Rust and Vala support</li>
@@ -59,7 +59,7 @@
       </description>
     </release>
     <release version="45" date="2023-09-22">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Use GNOME 45</li>
           <li>Support Rust</li>
@@ -124,7 +124,7 @@
       </description>
     </release>
     <release version="44.2" date="2023-06-23">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Improve Screenshot Preview</li>
           <li>Fix a bug causing preview to update on certain events</li>
@@ -163,7 +163,7 @@
       </description>
     </release>
     <release version="44.1" date="2023-05-17">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Update icon-development-kit; adds 143 new icons</li>
           <li>Update to Blueprint to 0.8.1</li>
@@ -173,7 +173,7 @@
       </description>
     </release>
     <release version="44.0" date="2023-04-15">
-      <description>
+      <description translatable="no">
         <ul>
           <li>GNOME 44</li>
           <li>Workbench is now fully sandboxed and will be considered safe</li>
@@ -188,7 +188,7 @@
       </description>
     </release>
     <release version="43.3" date="2023-01-23">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Switching between XML and Blueprint will now export</li>
           <li>Add support for JavaScript diagnostics and linting</li>
@@ -202,14 +202,14 @@
       </description>
     </release>
     <release version="43.2" date="2022-11-20">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix application not starting</li>
         </ul>
       </description>
     </release>
     <release version="43.1" date="2022-11-18">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Use Vala Language Server for diagnostics</li>
           <li>Move Icon Browser to the main application menu</li>
@@ -224,7 +224,7 @@
       </description>
     </release>
     <release version="43.0" date="2022-09-21">
-      <description>
+      <description translatable="no">
         <ul>
           <li>GNOME 43</li>
           <li>Display CSS errors inline</li>
@@ -237,7 +237,7 @@
       </description>
     </release>
     <release version="42.3" date="2022-08-22">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Show tooltip hints in Blueprint UI code</li>
           <li>Improve XML formatter</li>
@@ -250,7 +250,7 @@
       </description>
     </release>
     <release version="42.2" date="2022-07-19">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Underline errors in Blueprint UI code</li>
           <li>Fix bugs and crashes</li>
@@ -258,7 +258,7 @@
       </description>
     </release>
     <release version="42.1" date="2022-07-07">
-      <description>
+      <description translatable="no">
         <ul>
           <li
           >Add an Icon Browser to find the right icons for your prototypes</li>
@@ -280,7 +280,7 @@
       </description>
     </release>
     <release version="42.0" date="2022-06-04">
-      <description>
+      <description translatable="no">
         <p>Highlights</p>
         <ul>
           <li>Add Blueprint markup syntax for UI</li>
@@ -313,7 +313,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2022-05-06">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Add a Library of examples</li>
           <li>Add an example of WebSocket client</li>
@@ -333,7 +333,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2022-03-24">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Take a png screenshot of the preview</li>
           <li>The console is now resizable</li>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.