### PR TITLE
manuals: Fix a couple of bugs

### DIFF
--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -57,7 +57,7 @@
           <li>Add audio permission</li>
           <li>Make Workbench smaller and faster to download</li>
           <li>Library: Add CSS gradientts demo</li>
-          <li>Library: Add Proprty Row</li>
+          <li>Library: Add Property Row</li>
           <li>Library: Update entries to use SpinRow and SwitchRow </li>
           <li>Library: Port Map entry to Rust</li>
           <li>Library: Port Emoji Chooser to Rust</li>

--- a/src/Manuals/DocumentationViewer.blp
+++ b/src/Manuals/DocumentationViewer.blp
@@ -60,9 +60,8 @@ Adw.Window documentation_viewer {
             width-request: 400;
 
             ListView browse_list_view {
-              enable-rubberband: true;
+              enable-rubberband: false;
               factory: BuilderListItemFactory {
-
                 template ListItem {
                   child: TreeExpander expander {
                     list-row: bind template.item;
@@ -84,8 +83,9 @@ Adw.Window documentation_viewer {
             width-request: 400;
 
             ListView search_list_view {
-              enable-rubberband: true;
+              enable-rubberband: false;
               model: SingleSelection search_model {
+                autoselect: false;
                 model: SortListModel {
                   sorter: StringSorter search_sorter {};
                   model: FilterListModel filter_model {

--- a/src/Manuals/DocumentationViewer.blp
+++ b/src/Manuals/DocumentationViewer.blp
@@ -13,6 +13,7 @@ Adw.Window documentation_viewer {
 
   content: Adw.NavigationSplitView split_view {
     sidebar: Adw.NavigationPage sidebar {
+      title: bind documentation_viewer.title;
       child: Adw.ToolbarView {
         [top]
         Adw.HeaderBar {
@@ -113,22 +114,13 @@ Adw.Window documentation_viewer {
     };
 
     content: Adw.NavigationPage {
-      child: Adw.ToolbarView {
-        extend-content-to-top-edge: true;
-        [top]
-        Adw.HeaderBar {
-          show-title: false;
-          show-end-title-buttons: false;
-          show-start-title-buttons: false;
-        }
-
-        WebKit.WebView webview {
-          settings: WebKit.Settings {
-            enable-back-forward-navigation-gestures: true;
-            enable-developer-extras: true;
-            enable-smooth-scrolling: true;
-          };
-        }
+      title: bind documentation_viewer.title;
+      child: WebKit.WebView webview {
+        settings: WebKit.Settings {
+          enable-back-forward-navigation-gestures: true;
+          enable-developer-extras: true;
+          enable-smooth-scrolling: true;
+        };
       };
     };
   };

--- a/src/Manuals/DocumentationViewer.js
+++ b/src/Manuals/DocumentationViewer.js
@@ -142,14 +142,16 @@ export default function DocumentationViewer({ application }) {
   const filter = filter_model.filter;
   filter.expression = expr;
 
-  search_entry.connect("search-changed", () => {
+  function onSearchChanged() {
     if (search_entry.text) {
       stack.visible_child = search_page;
       filter.search = search_entry.text;
     } else {
       stack.visible_child = browse_page;
     }
-  });
+  }
+
+  search_entry.connect("search-changed", onSearchChanged);
 
   const search_model = builder.get_object("search_model");
   const sorter = builder.get_object("search_sorter");
@@ -197,6 +199,8 @@ export default function DocumentationViewer({ application }) {
       .then(() => {
         if (!mapped) {
           browse_list_view.model.selected = 12;
+          search_entry.text = "";
+          onSearchChanged();
         }
       })
       .catch(console.error);


### PR DESCRIPTION
* Select the text on search focus (ctrl+k) so the user can type something new to replace the previous search directly
* Fix libadwaita warnings about navigation page not having titles
* Fix an issue where you can't load (because of autoselect) the first filter result
* Reset Manuals when the window has been hidden and reopened (hide-on-close)
  * Focus the search
  * Reset search