### PR TITLE
Manuals: Sync the sidebar to search view and webview

### DIFF
--- a/src/Manuals/DocumentationViewer.js
+++ b/src/Manuals/DocumentationViewer.js
@@ -178,7 +178,7 @@ export default function DocumentationViewer({ application }) {
   search_model.connect("selection-changed", () => {
     const uri = search_model.selected_item.uri;
     const sidebar_path = URI_TO_SIDEBAR_PATH[uri];
-    selectSidebarItem(browse_selection_model, sidebar_path, browse_list_view);
+    selectSidebarItem(browse_list_view, sidebar_path);
   });
 
   let promise_load;


### PR DESCRIPTION
This PR makes the following changes
- Selecting an item in the search view will select the item in the browse view
- Any time the webview's uri changes due to going back/forward or clicking on a link within a documentation to another API reference will update the browse view as well
- The tree list model is now created in a sorted manner using https://docs.gtk.org/gio/method.ListStore.insert_sorted.html, instead of sorting it after the model is created