### PR TITLE
Fix Workbench not launching if shell isn't in Flatpak

### DIFF
--- a/src/workbench
+++ b/src/workbench
@@ -16,4 +16,4 @@ export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/us
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
 
-script --flush --quiet --return /var/tmp/workbench --command "@app_id@ $@"
+SHELL=/bin/sh script --flush --quiet --return /var/tmp/workbench --command "@app_id@ $@"


### PR DESCRIPTION
The `SHELL=/bin/sh` was previously there bot got removed. At least in the dev setup without this Workbench will not start if using a shell like `zsh` or `fish` on the host system.