### PR TITLE
Fix custom button missing highlight

### DIFF
--- a/src/Library/demos/Button/main.blp
+++ b/src/Library/demos/Button/main.blp
@@ -55,6 +55,10 @@ Adw.StatusPage {
         name: "custom";
         label: _("Custom");
         margin-end: 40;
+
+        styles [
+          "opaque",
+        ]
       }
 
       Button disabled {


### PR DESCRIPTION
Without the 'opaque' style the button will not have highlight. "Adwaita Demo" does the same thing.