### PR TITLE
Add workbench.build experimental API

### DIFF
--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -5,6 +5,7 @@ import GObject from "gi://GObject";
 import Adw from "gi://Adw";
 
 import { once } from "../../troll/src/async.js";
+import { build } from "../../troll/src/builder.js";
 
 // eslint-disable-next-line no-restricted-globals
 const { addSignalMethods } = imports.signals;
@@ -79,6 +80,10 @@ export default function Internal({
         dropdown_preview_align.visible = false;
         dropdown_preview_align.selected = 0;
         preview(object);
+      },
+      build(params) {
+        console.warn("workbench.build is experimental");
+        return build(panel_ui.xml, params);
       },
     };
 


### PR DESCRIPTION
Fixes https://github.com/sonnyp/Workbench/issues/667

Makes Workbench support signal handlers and closures for Gtk interface.
It uses https://github.com/sonnyp/troll#build