### PR TITLE
Less save prompts

### DIFF
--- a/src/PanelUI.js
+++ b/src/PanelUI.js
@@ -142,6 +142,10 @@ export default function PanelUI({
     }
   }
 
+  function is_xml_selected() {
+    return lang === lang_xml;
+  }
+
   const dropdown_selected_signal = listenProperty(
     dropdown_ui_lang,
     "selected",
@@ -194,6 +198,7 @@ export default function PanelUI({
   panel.start = start;
   panel.stop = stop;
   panel.update = update;
+  panel.is_xml_selected = is_xml_selected;
   panel.panel = panel_ui;
 
   return panel;

--- a/src/window.js
+++ b/src/window.js
@@ -197,12 +197,14 @@ export default function Window({ application, session }) {
       return;
     }
 
+    if (buffer.text === code) {
+      return;
+    }
+
     const { cursor_position } = buffer;
 
     code_view.replaceText(code, false);
     buffer.place_cursor(buffer.get_iter_at_offset(cursor_position));
-
-    return code;
   }
 
   function formatRustCode(text) {

--- a/src/window.js
+++ b/src/window.js
@@ -262,9 +262,11 @@ export default function Window({ application, session }) {
     }
 
     if (panel_ui.panel.visible) {
-      await format(langs.xml.document.code_view, (text) => {
-        return xml.format(text, 2);
-      });
+      if (panel_ui.is_xml_selected()) {
+        await format(langs.xml.document.code_view, (text) => {
+          return xml.format(text, 2);
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Currently there are 3 issues:

1. Formatted text is set to the GtkSourceView buffer, even if it is the same, raising safe notification.
2. UI XML is formatted is and set to the previously empty GtkSourceView buffer, even if the selected language is Blueprint.
3. The .js and .css files don't have empty line at the end, but formatting them adds one.

This pull request solves the first 2 issues, but I'm not sure what to do with the last one - trim the empty line after formatting or add one to all the sources?