### PR TITLE
library: Port Actions demo to Python

### DIFF
--- a/src/Library/demos/Actions/main.blp
+++ b/src/Library/demos/Actions/main.blp
@@ -163,6 +163,11 @@ Adw.StatusPage demo {
         }
 
         LinkButton {
+          label: _("PyGObjects Documentation");
+          uri: "https://pygobject.readthedocs.io";
+        }
+
+        LinkButton {
           label: _("GTK Documentation");
           uri: "https://docs.gtk.org/gtk4/actions.html";
         }

--- a/src/Library/demos/Actions/main.py
+++ b/src/Library/demos/Actions/main.py
@@ -1,0 +1,70 @@
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gtk, Adw, GLib, Gio
+import workbench
+
+demo: Adw.StatusPage = workbench.builder.get_object("demo")
+
+demo_group = Gio.SimpleActionGroup()
+demo.insert_action_group("demo", demo_group)
+
+# Action with no state or parameters
+simple_action = Gio.SimpleAction(
+  name = "simple"
+)
+
+simple_action.connect("activate",
+  lambda action, _ : print(f"{action.get_name()} action activated")
+)
+
+demo_group.add_action(simple_action)
+
+# Action with parameter
+bookmarks_action = Gio.SimpleAction(
+  name = "open-bookmarks",
+  parameter_type = GLib.VariantType("s"),
+)
+
+bookmarks_action.connect("activate",
+  lambda action, parameter : print(f"{action.get_name()} activated with {parameter.unpack()}")
+)
+
+demo_group.add_action(bookmarks_action)
+
+# Action with state
+toggle_action = Gio.SimpleAction(
+  name = "toggle",
+  # Boolean actions dont need parameters for activation
+  state = GLib.Variant.new_boolean(False),
+)
+
+toggle_action.connect("notify::state",
+  lambda action, _ : print(f"{action.get_name()} action set to {action.get_state().unpack()}")
+)
+
+demo_group.add_action(toggle_action)
+
+# Action with state and parameter
+scale_action = Gio.SimpleAction(
+  name = "scale",
+  state = GLib.Variant.new_string("100%"),
+  parameter_type = GLib.VariantType("s"),
+)
+
+scale_action.connect("notify::state",
+  lambda action, _ : print(f"{action.get_name()} action set to {action.get_state().unpack()}")
+)
+
+demo_group.add_action(scale_action)
+
+text : Gtk.Label = workbench.builder.get_object("text")
+
+alignment_action = Gio.PropertyAction(
+  name = "text-align",
+  object = text,
+  property_name = "halign",
+)
+
+demo_group.add_action(alignment_action)

--- a/src/Library/demos/Actions/main.py
+++ b/src/Library/demos/Actions/main.py
@@ -11,60 +11,69 @@ demo_group = Gio.SimpleActionGroup()
 demo.insert_action_group("demo", demo_group)
 
 # Action with no state or parameters
-simple_action = Gio.SimpleAction(
-  name = "simple"
-)
+simple_action = Gio.SimpleAction(name="simple")
 
-simple_action.connect("activate",
-  lambda action, _ : print(f"{action.get_name()} action activated")
+simple_action.connect(
+    "activate", lambda action, _: print(
+        f"{action.get_name()} action activated"
+    ),
 )
 
 demo_group.add_action(simple_action)
 
 # Action with parameter
 bookmarks_action = Gio.SimpleAction(
-  name = "open-bookmarks",
-  parameter_type = GLib.VariantType("s"),
+    name="open-bookmarks",
+    parameter_type=GLib.VariantType("s"),
 )
 
-bookmarks_action.connect("activate",
-  lambda action, parameter : print(f"{action.get_name()} activated with {parameter.unpack()}")
+bookmarks_action.connect(
+    "activate",
+    lambda action, parameter: print(
+        f"{action.get_name()} activated with {parameter.unpack()}"
+    ),
 )
 
 demo_group.add_action(bookmarks_action)
 
 # Action with state
 toggle_action = Gio.SimpleAction(
-  name = "toggle",
-  # Boolean actions dont need parameters for activation
-  state = GLib.Variant.new_boolean(False),
+    name="toggle",
+    # Boolean actions dont need parameters for activation
+    state=GLib.Variant.new_boolean(False),
 )
 
-toggle_action.connect("notify::state",
-  lambda action, _ : print(f"{action.get_name()} action set to {action.get_state().unpack()}")
+toggle_action.connect(
+    "notify::state",
+    lambda action, _: print(
+        f"{action.get_name()} action set to {action.get_state().unpack()}"
+    ),
 )
 
 demo_group.add_action(toggle_action)
 
 # Action with state and parameter
 scale_action = Gio.SimpleAction(
-  name = "scale",
-  state = GLib.Variant.new_string("100%"),
-  parameter_type = GLib.VariantType("s"),
+    name="scale",
+    state=GLib.Variant.new_string("100%"),
+    parameter_type=GLib.VariantType("s"),
 )
 
-scale_action.connect("notify::state",
-  lambda action, _ : print(f"{action.get_name()} action set to {action.get_state().unpack()}")
+scale_action.connect(
+    "notify::state",
+    lambda action, _: print(
+        f"{action.get_name()} action set to {action.get_state().unpack()}"
+    ),
 )
 
 demo_group.add_action(scale_action)
 
-text : Gtk.Label = workbench.builder.get_object("text")
+text: Gtk.Label = workbench.builder.get_object("text")
 
 alignment_action = Gio.PropertyAction(
-  name = "text-align",
-  object = text,
-  property_name = "halign",
+    name="text-align",
+    object=text,
+    property_name="halign",
 )
 
 demo_group.add_action(alignment_action)

--- a/src/about.js
+++ b/src/about.js
@@ -82,6 +82,7 @@ ${getBlueprintVersion()}
     "Onkar https://github.com/onkarrai06",
     "Sabrina Meindlhumer https://github.com/m-sabrina",
     "Urtsi Santsi <urtsi.santsi@proton.me>",
+    "Roland Lötscher https://github.com/rolandlo",
     // Add yourself as
     // "John Doe",
     // or


### PR DESCRIPTION
This PR ports the Actions demo to Python

I have tried to stay as close as possible to the JS code. Not sure if I should have avoided using lambdas as in the Welcome demo, see [comment](https://github.com/sonnyp/Workbench/pull/570/files#r1372677674). I used lambdas because here it's only for a single statement, whereas in the Welcome demo there were two statements.

The `open_uri` actions somehow don't work yet. Is this something that needs to be fixed on the "core" side or is there something wrong with my code?