### PR TITLE
Library: replace Box with FlowBox in Prefs. Window entry

### DIFF
--- a/src/Library/demos/Preferences Window/main.blp
+++ b/src/Library/demos/Preferences Window/main.blp
@@ -48,9 +48,14 @@ Adw.PreferencesWindow pref_window {
     Adw.PreferencesGroup {
       title: _("API References");
 
-      Box {
-        orientation: horizontal;
-        margin-top: 12;
+       FlowBox {
+          orientation: horizontal;
+          margin-top: 12;
+          row-spacing: 2;
+          column-spacing: 2;
+          homogeneous: true;
+          max-children-per-line: 4;
+          min-children-per-line: 1;
 
         LinkButton {
           label: _("PreferencesWindow");


### PR DESCRIPTION
intended to fix #677

![image](https://github.com/sonnyp/Workbench/assets/103920890/c75797f0-4e56-4557-a70f-2ed72f334e5b)

API Reference linkbuttons are now adaptable.