### PR TITLE
python: Init GtkSource (+ minor formatting/style fixes)

### DIFF
--- a/src/Library/demos/Menu Button/main.py
+++ b/src/Library/demos/Menu Button/main.py
@@ -17,4 +17,3 @@ def update_css(_widget, _params):
 
 
 circular_switch.connect("notify::active", update_css)
-

--- a/src/Library/demos/Popovers/main.py
+++ b/src/Library/demos/Popovers/main.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 import workbench
 
 
-def onClosed(popover):
+def on_closed(popover):
     name = popover.get_name()
     print(f"{name} closed.")
 
@@ -14,4 +14,4 @@ popover_ids = ("plain_popover", "popover_menu")
 
 for id in popover_ids:
     popover = workbench.builder.get_object(id)
-    popover.connect("closed", onClosed)
+    popover.connect("closed", on_closed)

--- a/src/langs/python/python-previewer.py
+++ b/src/langs/python/python-previewer.py
@@ -23,9 +23,13 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 gi.require_version("Graphene", "1.0")
 gi.require_version("Gsk", "4.0")
+gi.require_version("GtkSource", "5")
 
-from gi.repository import GLib, Gdk, Gtk, Adw, Graphene, Gio, Gsk
+from gi.repository import GObject, GLib, Gdk, Gtk, Adw, Graphene, Gio, Gsk, GtkSource
 from gi.repository.Gio import DBusConnection, DBusConnectionFlags
+
+# Load non-GTK widget types
+GtkSource.init()
 
 
 # Table of Contents

--- a/src/langs/python/python-previewer.py
+++ b/src/langs/python/python-previewer.py
@@ -25,7 +25,7 @@ gi.require_version("Graphene", "1.0")
 gi.require_version("Gsk", "4.0")
 gi.require_version("GtkSource", "5")
 
-from gi.repository import GObject, GLib, Gdk, Gtk, Adw, Graphene, Gio, Gsk, GtkSource
+from gi.repository import GLib, Gdk, Gtk, Adw, Graphene, Gio, Gsk, GtkSource
 from gi.repository.Gio import DBusConnection, DBusConnectionFlags
 
 # Load non-GTK widget types


### PR DESCRIPTION
I did not realize one needed to call `GtkSource.init()` from PyGObject. Currently PyGObject automatically inits the core namespaces, so I figured it did the same for `GtkSource` (this is also what I remembered from other apps I worked on).

Also contains one code style fix and one formatting fix for demos.
