### PR TITLE
python: Fix initializations

### DIFF
--- a/src/langs/python/python-previewer.py
+++ b/src/langs/python/python-previewer.py
@@ -28,7 +28,9 @@ gi.require_version("GtkSource", "5")
 from gi.repository import GLib, Gdk, Gtk, Adw, Graphene, Gio, Gsk, GtkSource
 from gi.repository.Gio import DBusConnection, DBusConnectionFlags
 
-# Load non-GTK widget types
+# Make sure all libraries are properly initialized
+Gtk.init()
+Adw.init()
 GtkSource.init()
 
 


### PR DESCRIPTION
This makes sure `Gtk` and `Adw` are really properly initialized. 
I haven't found any init calls in any of the other demos or Workbench itself, so this should be all.