### PR TITLE
Manual: Add forward and backward mouse gestures.

### DIFF
--- a/src/Manuals/DocumentationViewer.js
+++ b/src/Manuals/DocumentationViewer.js
@@ -87,6 +87,28 @@ export default function DocumentationViewer({ application }) {
   const search_entry = builder.get_object("search_entry");
   const button_shortcuts = builder.get_object("button_shortcuts");
 
+  const forward_backward_click = (isForward) => {
+    const gesture = new Gtk.GestureClick();
+    if (isForward) {
+      gesture.connect("pressed", () => {
+        webview.go_forward();
+      });
+      gesture.set_button(9);
+      return gesture;
+    }
+    gesture.connect("pressed", () => {
+      webview.go_back();
+    });
+    gesture.set_button(8);
+    return gesture;
+  };
+
+  window.add_controller(forward_backward_click(true));
+  window.add_controller(forward_backward_click(false));
+
+  webview.add_controller(forward_backward_click(true));
+  webview.add_controller(forward_backward_click(false));
+
   const onGoForward = () => {
     webview.go_forward();
   };


### PR DESCRIPTION
I have a mouse that has these buttons on the side. Many applications such as browsers use them for going forward and backwards.

I've tried adding the GestureClick to the document_viewer template but it only added the GestureClick to the sidebar for some reason.