### PR TITLE
Fix CSS provider priority

### DIFF
--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -215,7 +215,8 @@ export default function Internal({
     Gtk.StyleContext.add_provider_for_display(
       output.get_display(),
       css_provider,
-      Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+      // STYLE_PROVIDER_PRIORITY_THEME is 200; only values below that behave correctly
+      Gtk.STYLE_PROVIDER_PRIORITY_THEME - 1,
     );
   }
 

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -125,7 +125,11 @@ namespace Workbench {
         this.css_parser_error(error.message, (int)start.lines, (int)start.line_chars, (int)end.lines, (int)end.line_chars);
       });
       this.css.load_from_data (content.data);
-      Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), this.css , Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+      Gtk.StyleContext.add_provider_for_display (
+        Gdk.Display.get_default (),
+        this.css,
+        // STYLE_PROVIDER_PRIORITY_THEME is 200; only values below that behave correctly
+        Gtk.STYLE_PROVIDER_PRIORITY_THEME - 1);
     }
 
     public void run (string filename, string uri) {


### PR DESCRIPTION
For some reason, some classes from libadwaita wouldn't work properly with this css provider priority. For example label.accent