### PR TITLE
Composite template support for Vala, Rust, Python + "Custom Widget" demo

### DIFF
--- a/src/Library/demos/Custom Widget/code.rs
+++ b/src/Library/demos/Custom Widget/code.rs
@@ -1,0 +1,66 @@
+use crate::workbench;
+use gtk::{glib, subclass::prelude::*};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk::CompositeTemplate)]
+    // The file will be provided by Workbench when the demo compiles, it just contains the template.
+    #[template(file = "workbench_template.ui")]
+    pub struct AwesomeButton {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AwesomeButton {
+        const NAME: &'static str = "AwesomeButton";
+        type Type = super::AwesomeButton;
+        type ParentType = gtk::Button;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[gtk::template_callbacks]
+    impl AwesomeButton {
+        #[template_callback]
+        fn onclicked(_button: &gtk::Button) {
+            println!("Clicked")
+        }
+    }
+
+    impl ObjectImpl for AwesomeButton {}
+    impl WidgetImpl for AwesomeButton {}
+    impl ButtonImpl for AwesomeButton {}
+}
+
+glib::wrapper! {
+    pub struct AwesomeButton(ObjectSubclass<imp::AwesomeButton>) @extends gtk::Widget, gtk::Button;
+}
+
+impl AwesomeButton {
+    pub fn new() -> Self {
+        glib::Object::new()
+    }
+}
+
+pub fn main() {
+    gtk::init().unwrap();
+
+    let container = gtk::ScrolledWindow::new();
+    let flow_box = gtk::FlowBox::builder().hexpand(true).build();
+    container.set_child(&flow_box);
+
+    let mut widgets = Vec::with_capacity(100);
+    for _ in 0..100 {
+        widgets.push(AwesomeButton::new());
+    }
+    for widget in &widgets {
+        flow_box.append(widget);
+    }
+
+    workbench::preview(&container)
+}

--- a/src/Library/demos/Custom Widget/main.py
+++ b/src/Library/demos/Custom Widget/main.py
@@ -1,0 +1,28 @@
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk
+import workbench
+
+
+@Gtk.Template(string=workbench.template)
+class AwesomeButton(Gtk.Button):
+    # This is normally just "AwesomeButton" as defined in the XML/Blueprint.
+    # In your actual code, just put that here. We need to do it like this for technical reasons.
+    __gtype_name__ = workbench.template_gtype_name
+
+    @Gtk.Template.Callback()
+    def onclicked(self, _button):
+        print("Clicked")
+
+
+container = Gtk.ScrolledWindow()
+flow_box = Gtk.FlowBox(hexpand=True)
+container.set_child(flow_box)
+
+for _ in range(100):
+    widget = AwesomeButton()
+    flow_box.append(widget)
+
+workbench.preview(container)

--- a/src/Library/demos/Custom Widget/main.vala
+++ b/src/Library/demos/Custom Widget/main.vala
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S vala workbench.vala workbench.Resource.c  --gresources=workbench_demo.xml --pkg gtk4
+
+// The resource will be provided by Workbench when the demo compiles, see shebang above.
+[GtkTemplate (ui = "/re/sonny/Workbench/demo/workbench_template.ui")]
+public class AwesomeButton : Gtk.Button {
+	[GtkCallback]
+	private void onclicked (Gtk.Button button) {
+		message ("Clicked");
+	}
+}
+
+public void main () {
+  var container = new Gtk.ScrolledWindow();
+  var flow_box = new Gtk.FlowBox() {
+    hexpand = true
+  };
+  container.set_child(flow_box);
+
+  for (var i = 0; i < 100; i++) {
+    var widget = new AwesomeButton();
+    flow_box.append(widget);
+  }
+
+  workbench.preview(container);
+}

--- a/src/Previewer/External.js
+++ b/src/Previewer/External.js
@@ -1,5 +1,6 @@
 import Adw from "gi://Adw";
 import dbus_previewer from "./DBusPreviewer.js";
+import { decode } from "../util.js";
 
 export default function External({ output, builder, onWindowChange }) {
   const stack = builder.get_object("stack_preview");
@@ -57,9 +58,21 @@ export default function External({ output, builder, onWindowChange }) {
       .catch(console.error);
   }
 
-  async function updateXML({ xml, target_id, original_id }) {
+  async function updateXML({
+    xml,
+    target_id,
+    original_id,
+    template_gtype_name,
+    template,
+  }) {
     try {
-      await dbus_proxy.UpdateUiAsync(xml, target_id, original_id || "");
+      await dbus_proxy.UpdateUiAsync(
+        xml,
+        target_id,
+        original_id || "",
+        template_gtype_name || "",
+        template ? decode(template) : "",
+      );
     } catch (err) {
       console.debug(err);
     }

--- a/src/Previewer/TemplateResource.js
+++ b/src/Previewer/TemplateResource.js
@@ -1,0 +1,57 @@
+import Gio from "gi://Gio";
+import { encode } from "../util.js";
+
+function files(demoDirectory) {
+  return {
+    template_ui: demoDirectory.get_child("workbench_template.ui"),
+    gresource: demoDirectory.get_child("workbench_demo.xml"),
+  };
+}
+
+function generateGresource(templateName) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/re/sonny/Workbench/demo">
+    <file>${templateName}</file>
+  </gresource>
+</gresources>`;
+}
+
+/**
+ * Utilities for writing composite templates to the demo session directory and generating a gresource file for it.
+ * This can be used by external previewers that need this information at compile time and can not retrieve the
+ * template via D-Bus + the previewer process.
+ */
+const template_resource = {
+  async generateTemplateResourceFile(sessionDirectory) {
+    const { template_ui, gresource } = files(sessionDirectory);
+    await gresource.replace_contents_async(
+      encode(generateGresource(template_ui.get_basename())),
+      null,
+      false,
+      Gio.FileCreateFlags.NONE,
+      null,
+    );
+    return gresource.get_path();
+  },
+  async writeTemplateUi(sessionDirectory, templateContents) {
+    if (templateContents === null) {
+      // If we don't have a template, we still generate an empty file to (try to) avoid confusing compiler errors if
+      // the user tries to access the file via gresource.
+      templateContents = encode(
+        '<?xml version="1.0" encoding="UTF-8"?><interface></interface>',
+      );
+    }
+
+    const { template_ui } = files(sessionDirectory);
+    await template_ui.replace_contents_async(
+      encode(templateContents),
+      null,
+      false,
+      Gio.FileCreateFlags.NONE,
+      null,
+    );
+  },
+};
+
+export default template_resource;

--- a/src/Previewer/previewer.vala
+++ b/src/Previewer/previewer.vala
@@ -65,7 +65,10 @@ namespace Workbench {
       typeof (WebKit.WebView).ensure();
     }
 
-    public void update_ui (string content, string target_id, string original_id = "") {
+    public void update_ui (string content, string target_id, string original_id = "", string template_gtype_name = "", string template = "") {
+      // we don't use template: This is compiled as a gresource for Vala and for Rust it's read directly
+      // and compiled from a path to the UI file. See Rust/Vala compiler.
+
       this.ensure_types();
       this.builder = new Gtk.Builder.from_string (content, content.length);
       var target = this.builder.get_object (target_id) as Gtk.Widget;
@@ -186,6 +189,10 @@ namespace Workbench {
 
     public void enable_inspector (bool enabled) {
       Gtk.Window.set_interactive_debugging (enabled);
+    }
+
+    public void preview() {
+
     }
 
     public Adw.ColorScheme ColorScheme { get; set; default = Adw.ColorScheme.DEFAULT; }

--- a/src/Previewer/previewer.xml
+++ b/src/Previewer/previewer.xml
@@ -4,6 +4,8 @@
       <arg type="s" name="content" direction="in"/>
       <arg type="s" name="target_id" direction="in"/>
       <arg type="s" name="original_id" direction="in"/>
+      <arg type="s" name="template_gtype_name" direction="in"/>
+      <arg type="s" name="template" direction="in"/>
     </method>
     <method name="UpdateCss">
       <arg type="s" name="content" direction="in"/>

--- a/src/langs/rust/Compiler.js
+++ b/src/langs/rust/Compiler.js
@@ -2,6 +2,7 @@ import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import dbus_previewer from "../../Previewer/DBusPreviewer.js";
 import { decode, encode } from "../../util.js";
+import template_resource from "../../Previewer/TemplateResource.js";
 
 export default function Compiler({ session }) {
   const { file } = session;
@@ -14,7 +15,7 @@ export default function Compiler({ session }) {
   let rustcVersion;
   let savedRustcVersion;
 
-  async function compile() {
+  async function compile(template) {
     rustcVersion ||= await getRustcVersion();
     savedRustcVersion ||= await getSavedRustcVersion({ rustcVersionFile });
 
@@ -22,6 +23,8 @@ export default function Compiler({ session }) {
       await cargoClean({ file, targetPath });
       await saveRustcVersion({ targetPath, rustcVersion, rustcVersionFile });
     }
+
+    await template_resource.writeTemplateUi(file, template);
 
     const cargo_launcher = new Gio.SubprocessLauncher();
     cargo_launcher.set_cwd(file.get_path());

--- a/src/langs/rust/template/workbench.rs
+++ b/src/langs/rust/template/workbench.rs
@@ -33,3 +33,12 @@ pub(crate) fn resolve(path: impl AsRef<Path>) -> String {
             .to_string()
     }
 }
+
+#[allow(dead_code)]
+pub(crate) fn preview(widget: &impl IsA<gtk::Widget>) {
+    // TODO: We would now need to actually somehow communicate back to the
+    //       previewer.vala itself to set it's target and ensure_window...
+    // this.target = widget;
+    // this.ensure_window();
+    // this.window.set_child(widget);
+}

--- a/src/langs/vala/workbench.vala
+++ b/src/langs/vala/workbench.vala
@@ -2,6 +2,13 @@ namespace workbench {
     public static Gtk.Builder builder;
     public static Gtk.Window window;
     public static string uri;
+    public void preview (Gtk.Widget widget) {
+      // TODO: We would now need to actually somehow communicate back to the
+      //       previewer.vala itself to set it's target and ensure_window...
+      // this.target = widget;
+      // this.ensure_window();
+      // this.window.set_child(widget);
+    }
     public string resolve (string path) {
         return File.new_for_uri(workbench.uri).resolve_relative_path(path).get_uri();
     }

--- a/src/window.js
+++ b/src/window.js
@@ -378,10 +378,12 @@ export default function Window({ application, session }) {
         return;
       }
 
+      await previewer.useExternal("vala");
+      const { template } = await previewer.update(true);
+
       compiler_vala = compiler_vala || ValaCompiler({ session });
-      const success = await compiler_vala.compile();
+      const success = await compiler_vala.compile(template);
       if (success) {
-        await previewer.useExternal("vala");
         if (await compiler_vala.run()) {
           await previewer.open();
         } else {
@@ -394,10 +396,12 @@ export default function Window({ application, session }) {
         return;
       }
 
+      await previewer.useExternal("rust");
+      const { template } = await previewer.update(true);
+
       compiler_rust = compiler_rust || RustCompiler({ session });
-      const success = await compiler_rust.compile();
+      const success = await compiler_rust.compile(template);
       if (success) {
-        await previewer.useExternal("rust");
         if (await compiler_rust.run()) {
           await previewer.open();
         } else {


### PR DESCRIPTION
This is my attempt to get composite templates working for the other langs.

I say attempt, because it doesn't actually work. There are a lot of reasons, and it boils down to that this probably would require approaching the external previewers completely different.

The main remaining/blocking issue is the fact that the class names need to be counted up to avoid collisions. but Python, Vala and Rust expect the class name to match exactly what's in the demo while the current GJS demo doesn't seem to mind the mismatch.
I worked around that for Python by getting the gtype name from the Workbench API, but for the others this is much more complicated due to the fact that it needs to be compiled. I'm not sure how to get the modified class name in there. Maybe we need to just not add a number to it for those two and restart the previewer every time.
The Python code currently launches once. After that it doesn't anymore, since it tries to re-register the object. Modification would probably be needed to always count up on launch, not just when the XML changes, or the previewer would just also need to be restarted every time. In that case we should just get rid of the number for all external demos and restart the previewer on every launch if templates are involved.

Another issue is that the Vala/Rust code would need to modify the internal state of the previewer to set the "target", but since they are linked in as shared objects there's no easy way to communicate back here.

And I needed to change how the dummy target is handled, replacing it just with an empty box so that the Python and Vala previewers don't crash trying to initialize it's signal handlers. Weirdly this kinda breaks Blueprint, it's trying to display the internal previewer now for non-JS demos. But maybe that's not related.
