### PR TITLE
Scope CSS to the current window

### DIFF
--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -46,6 +46,7 @@
       <description translatable="no">
         <ul>
           <li>Restore on-disk projects on startup</li>
+          <li>Prevent Style from affecting other windows</li>
           <li>Library: Port "Accessibility" entry to Python</li>
           <li>Library: Port "Account" entry to Python</li>
           <li>Library: Port "Email" entry to Python</li>

--- a/src/Previewer/Internal.js
+++ b/src/Previewer/Internal.js
@@ -20,6 +20,11 @@ export default function Internal({
   panel_ui,
   session,
 }) {
+  const inline_css_scope_target = output.get_parent();
+  inline_css_scope_target.name = `workbench_output-${session.id}`;
+
+  let css_scope_target = inline_css_scope_target;
+
   const bus = {};
   addSignalMethods(bus);
 
@@ -174,8 +179,10 @@ export default function Internal({
     }
 
     if (!object_root.name) {
-      object_root.name = "workbench_output";
+      object_root.name = `workbench_output-${session.id}`;
     }
+
+    css_scope_target = object_root;
 
     return object_root;
   }
@@ -183,6 +190,7 @@ export default function Internal({
   function updateBuilderNonRoot(object_preview) {
     object_root?.destroy();
     object_root = null;
+    css_scope_target = inline_css_scope_target;
 
     stack.set_visible_child_name("inline");
     preview(object_preview);
@@ -204,7 +212,7 @@ export default function Internal({
     if (style.match(/#$/g)) return;
 
     try {
-      style = scopeStylesheet(style, object_root?.name);
+      style = scopeStylesheet(style, css_scope_target.name);
     } catch (err) {
       console.debug(err);
       // logError(err);
@@ -246,11 +254,9 @@ export default function Internal({
 // because it's not compatible with postcss 8
 function scopeStylesheet(style, id) {
   const ast = postcss.parse(style);
-  id = id || "workbench_output";
-
   for (const node of ast.nodes) {
     if (node.selector === "window") {
-      node.selector = `window#${id}`;
+      node.selector = `#${id}`;
     } else if (node.selector) {
       node.selector = `#${id} ${node.selector}`;
     }

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -141,6 +141,7 @@ To open and run this; [install Workbench from Flathub](https://flathub.org/apps/
 export class Session {
   file = null;
   settings = null;
+  id = Math.random().toString().substring(2);
 
   constructor(file) {
     this.file = file;

--- a/src/window.blp
+++ b/src/window.blp
@@ -393,7 +393,6 @@ Adw.ApplicationWindow window {
 
                 child: Box {
                   ScrolledWindow {
-                    name: "workbench_output";
                     vexpand: true;
                     hexpand: true;
 


### PR DESCRIPTION
This fixes the issue of CSS in one session affecting the preview in another session when using the internal previewer. 

![Screenshot from 2023-11-26 14-46-05](https://github.com/workbenchdev/Workbench/assets/19673/5c2e9283-78e0-4280-a584-ea5b81978ada)
