### PR TITLE
Add WebP image format support

### DIFF
--- a/build-aux/modules/webp-pixbuf-loader.json
+++ b/build-aux/modules/webp-pixbuf-loader.json
@@ -1,0 +1,19 @@
+{
+  "name": "webp-pixbuf-loader",
+  "buildsystem": "meson",
+  "config-opts": [
+    "-Dgdk_pixbuf_moduledir=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/aruiz/webp-pixbuf-loader.git",
+      "tag": "0.2.4",
+      "commit": "a35014104a226265e44fe30fcdb4df9305af3466"
+    }
+  ],
+  "post-install": [
+    "GDK_PIXBUF_MODULEDIR=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/ gdk-pixbuf-query-loaders > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+    "gdk-pixbuf-query-loaders >> /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+  ]
+}

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -44,6 +44,7 @@
     "modules/libspelling.json",
     "modules/GTKCssLanguageServer.json",
     "modules/icon-development-kit.json",
+    "modules/webp-pixbuf-loader.json",
     {
       "name": "Workbench",
       "buildsystem": "meson",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -44,6 +44,7 @@
     "modules/libspelling.json",
     "modules/GTKCssLanguageServer.json",
     "modules/icon-development-kit.json",
+    "modules/webp-pixbuf-loader.json",
     {
       "name": "Workbench",
       "buildsystem": "meson",

--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -48,6 +48,7 @@
           <li>Restore on-disk projects on startup</li>
           <li>Prevent Style from affecting other windows</li>
           <li>Fix Console style when toggling dark mode</li>
+          <li>Add WebP image format support</li>
           <li>Library: Port "Accessibility" entry to Python</li>
           <li>Library: Port "Account" entry to Python</li>
           <li>Library: Port "Email" entry to Python</li>

--- a/src/workbench
+++ b/src/workbench
@@ -16,6 +16,9 @@ export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/us
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
 
+
+export GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+
 # We do not support translations but the AboutWindow is translated by default
 LANG=en_US.UTF-8
 


### PR DESCRIPTION
webp is everywhere now and chances are the images downloaded from the Web by the users will be webp

Request to add to sdk/platform: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/merge_requests/2507