### PR TITLE
Add recommended gvfs permissions

### DIFF
--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -19,7 +19,9 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--socket=pulseaudio"
+    "--socket=pulseaudio",
+    "--talk-name=org.gtk.vfs.*",
+    "--filesystem=xdg-run/gvfsd"
   ],
   "cleanup": [
     "/include",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -19,7 +19,9 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--socket=pulseaudio"
+    "--socket=pulseaudio",
+    "--talk-name=org.gtk.vfs.*",
+    "--filesystem=xdg-run/gvfsd"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
Solves the following error in Console

> GVFS-cannot open directory /usr/share/gvfs/remote-volume-monitors: Error opening directory “/usr/share/gvfs/remote-volume-monitors”: No such file or directory

See https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access

> Typical GNOME and GTK applications should use:
> --talk-name=org.gtk.vfs.*
> --filesystem=xdg-run/gvfsd

However I still don't know if this is considered safe by Flathub / Software.
I would test but apparently GNOME Software is unable to show details for a locally installd app `gnome-software --details=re.sonny.Workbench.Devel`