### PR TITLE
Use the same env for cli

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -14,7 +14,7 @@ imports.package.init({
   datadir: "@datadir@",
 });
 
-const app_id = "re.sonny.Workbench.cli";
+const app_id = "@app_id@.cli";
 
 setConsoleLogDomain(app_id);
 GLib.set_application_name("workbench-cli");

--- a/src/cli/meson.build
+++ b/src/cli/meson.build
@@ -12,17 +12,17 @@ gjspack = find_program('../../troll/gjspack/bin/gjspack')
 
 configure_file(
   input: 'bin.js',
-  output: 'workbench-cli',
+  output: app_id + '.cli',
   configuration: bin_conf,
   install: true,
   install_dir: get_option('bindir')
 )
 custom_target('workbench-cli',
   input: ['main.js'],
-  output: 're.sonny.Workbench.cli.src.gresource',
+  output: app_id + '.cli.src.gresource',
   command: [
     gjspack,
-    '--appid=re.sonny.Workbench.cli',
+    '--appid=' + app_id + '.cli',
     '--prefix', '/re/sonny/Workbench',
     '--project-root', meson.project_source_root(),
     '--resource-root', meson.project_source_root() / 'src',
@@ -31,6 +31,6 @@ custom_target('workbench-cli',
     '@OUTDIR@',
   ],
   install: true,
-  install_dir: datadir / 're.sonny.Workbench.cli',
+  install_dir: datadir / app_id + '.cli',
   build_always_stale: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ bin_conf.set('libdir', join_paths(get_option('prefix'), get_option('libdir')))
 bin_conf.set('datadir', datadir)
 bin_conf.set('pkgdatadir', pkgdatadir)
 bin_conf.set('sourcedir', meson.project_source_root())
+bin_conf.set('command', 'SHELL=/bin/sh script --flush --quiet --return $XDG_RUNTIME_DIR/$FLATPAK_ID/typescript --command "' + app_id + ' $@"')
 
 blueprint_compiler = find_program(
   '/app/bin/blueprint-compiler',
@@ -29,6 +30,17 @@ configure_file(
   input: 'workbench',
   output: 'workbench',
   configuration: bin_conf,
+  install: true,
+  install_dir: get_option('bindir')
+)
+
+clibin_conf = configuration_data()
+clibin_conf.merge_from(bin_conf)
+clibin_conf.set('command', app_id + '.cli "$@"')
+configure_file(
+  input: 'workbench',
+  output: 'workbench-cli',
+  configuration: clibin_conf,
   install: true,
   install_dir: get_option('bindir')
 )

--- a/src/workbench
+++ b/src/workbench
@@ -22,4 +22,4 @@ export GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 LANG=en_US.UTF-8
 
 mkdir -p $XDG_RUNTIME_DIR/$FLATPAK_ID
-SHELL=/bin/sh script --flush --quiet --return $XDG_RUNTIME_DIR/$FLATPAK_ID/typescript --command "@app_id@ $@"
+@command@


### PR DESCRIPTION
Update `src/workbench` to accept the launch command as a meson variable. 
And use `src/workbench` for `workbench-cli`

So that workbench and workbench-cli share the same env.

Right now `workbench-cli` fails because `vala-language-server` isn't in path for example.