### PR TITLE
Update VTE 0.76

### DIFF
--- a/build-aux/modules/vte.json
+++ b/build-aux/modules/vte.json
@@ -11,8 +11,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/vte/0.75/vte-0.75.92.tar.xz",
-      "sha256": "3e805c9ac0fcdf3a11b51d77dd8a98efadba74cfade385951c3d378d156c7023"
+      "url": "https://download.gnome.org/sources/vte/0.76/vte-0.76.0.tar.xz",
+      "sha256": "bbce30b8f504370b12d6439c07a82993e97d7e9afe2dd367817cd58ff029ffda"
     }
   ]
 }

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -9,6 +9,7 @@ import Gtk from "gi://Gtk";
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
 import Shumate from "gi://Shumate";
+import WebKit from "gi://WebKit";
 
 import { parse } from "../langs/xml/xml.js";
 import { LSPError, diagnostic_severities } from "../lsp/LSP.js";
@@ -23,6 +24,7 @@ import lint, { waitForDiagnostics } from "./lint.js";
 import format, { formatting } from "./format.js";
 
 GObject.type_ensure(Shumate.SimpleMap);
+GObject.type_ensure(WebKit.WebView);
 
 export async function main([action, ...args]) {
   const current_dir = Gio.File.new_for_path(GLib.get_current_dir());


### PR DESCRIPTION
Blocked on

```
Dependency gtk4 found: NO found 4.13.9 but need: '>=4.14.0'
Found CMake: /usr/bin/cmake (3.28.3)
Run-time dependency gtk4 found: NO (tried cmake)

../meson.build:636:13: ERROR: Dependency lookup for gtk4 with method 'pkgconfig' failed: Invalid version, need 'gtk4' ['>=4.14.0'] found '4.13.9'.

A full log can be found at /run/build/vte/_flatpak_build/meson-logs/meson-log.txt
Error: module vte: Child process exited with code 1
```

https://matrix.to/#/!yuQLuKxKpBnxkDTHuD:gnome.org/$RHg4WPvVXNtA5dgd0kG5AXe5FNx04fFaivaGKSki38w?via=matrix.org&via=gnome.org&via=fedora.im