### PR TITLE
Drop LLVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL:=/bin/bash -O globstar
 setup:
 	flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 # flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//46 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08 org.freedesktop.Sdk.Extension.llvm16//23.08
+	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//46 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08
 	npm install
 	make build
 
@@ -58,7 +58,7 @@ ci: setup test
 # make sure to test without the sdk extensions installed
 sandbox: setup
 	flatpak-builder --ccache --user --install --force-clean flatpak build-aux/re.sonny.Workbench.Devel.json
-# flatpak remove --noninteractive org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08 org.freedesktop.Sdk.Extension.llvm16//23.08
+# flatpak remove --noninteractive org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08
 	flatpak run --command="bash" re.sonny.Workbench.Devel
 
 flatpak:

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -5,8 +5,7 @@
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.vala",
-    "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm16"
+    "org.freedesktop.Sdk.Extension.rust-stable"
   ],
   "build-options": {
     "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -5,8 +5,7 @@
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.vala",
-    "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm16"
+    "org.freedesktop.Sdk.Extension.rust-stable"
   ],
   "build-options": {
     "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin",

--- a/src/Extensions/Extensions.blp
+++ b/src/Extensions/Extensions.blp
@@ -53,8 +53,9 @@ Adw.Dialog dialog {
 
             $Extension extension_rust {
               title: _("Rust");
-              hint: _("Run the following command");
-              command: "flatpak install flathub org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.llvm16//23.08";
+              hint: _("or run the following command");
+              command: "flatpak install flathub org.freedesktop.Sdk.Extension.rust-stable//23.08";
+              uri: "appstream://org.freedesktop.Sdk.Extension.rust-stable";
             }
 
             $Extension extension_vala {

--- a/src/Extensions/Extensions.js
+++ b/src/Extensions/Extensions.js
@@ -43,9 +43,9 @@ export function Extensions({ window }) {
 
 let rust_enabled;
 export function isRustEnabled() {
-  rust_enabled ??=
-    Gio.File.new_for_path("/usr/lib/sdk/rust-stable").query_exists(null) &&
-    Gio.File.new_for_path("/usr/lib/sdk/llvm16").query_exists(null);
+  rust_enabled ??= Gio.File.new_for_path(
+    "/usr/lib/sdk/rust-stable",
+  ).query_exists(null);
   return rust_enabled;
 }
 

--- a/src/workbench
+++ b/src/workbench
@@ -7,13 +7,6 @@ export PKG_CONFIG_PATH=/app/lib/pkgconfig/:$PKG_CONFIG_PATH
 
 source /usr/lib/sdk/rust-stable/enable.sh 2> /dev/null
 source /usr/lib/sdk/vala/enable.sh 2> /dev/null
-source /usr/lib/sdk/llvm16/enable.sh 2> /dev/null
-
-# TODO: Figure out how to use gcc with mold so we can drop llvm
-export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
-export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
 
 # We do not support translations but the AboutWindow is translated by default
 LANG=en_US.UTF-8


### PR DESCRIPTION
Fixes https://github.com/workbenchdev/Workbench/issues/611

I tried to make mold work with gcc with `-C link-arg=-fuse-ld=mold -C link-arg=-B=/usr/lib/sdk/rust-stable/` but it resulted in `note: collect2: fatal error: cannot find 'ld'`

Anyway, I can't see a difference with our without Mold - could it be the gnu linker is substantially faster now?

@Hofer-Julian wdyt?