### PR TITLE
draft: Add shortcuts in UI panel to show XML and blueprint (#929)

### DIFF
--- a/src/PanelUI.js
+++ b/src/PanelUI.js
@@ -64,6 +64,36 @@ export default function PanelUI({
     code_view_xml.replaceText(xml);
   }
 
+  const showXML = new Gio.SimpleAction({
+    name: "showXML",
+    parameter_type: null,
+  });
+  const showBluePrint = new Gio.SimpleAction({
+    name: "showBlueprint",
+    parameter_type: null,
+  });
+
+  showXML.connect("activate", () => {
+    onChangeLang(lang_xml);
+    dropdown_selected_signal.block();
+    dropdown_ui_lang.set_selected(ui_languages.indexOf(lang_xml));
+    dropdown_selected_signal.unblock();
+  });
+
+  showBluePrint.connect("activate", () => {
+    onChangeLang(lang_blueprint);
+
+    dropdown_selected_signal.block();
+    dropdown_ui_lang.set_selected(ui_languages.indexOf(lang_blueprint));
+    dropdown_selected_signal.unblock();
+  });
+
+  application.add_action(showXML);
+  application.add_action(showBluePrint);
+
+  application.set_accels_for_action("app.showXML", ["<Control><Shift>X"]);
+  application.set_accels_for_action("app.showBlueprint", ["<Control><Shift>B"]);
+
   async function convertToBlueprint() {
     term_console.clear();
     settings.set_boolean("show-console", true);

--- a/src/about.js
+++ b/src/about.js
@@ -85,6 +85,7 @@ ${getBlueprintVersion()}
     "Bharat Tyagi https://github.com/BharatAtbrat",
     "Jan Fooken https://git.janvhs.com",
     "Vladimir Vaskov https://github.com/Rirusha",
+    "Devan P https://github.com/DevHyperCoder",
     // Add yourself as
     // "John Doe",
     // or

--- a/src/shortcutsWindow.blp
+++ b/src/shortcutsWindow.blp
@@ -80,6 +80,16 @@ ShortcutsWindow window {
         accelerator: "<Control><Shift>Z";
         title: _("Redo");
       }
+
+      ShortcutsShortcut {
+        accelerator: "<Control><Shift>X";
+        title: _("Show XML in UI panel");
+      }
+
+      ShortcutsShortcut {
+        accelerator: "<Control><Shift>B";
+        title: _("Show blueprint in UI panel");
+      }
     }
 
     ShortcutsGroup {


### PR DESCRIPTION
Referencing to the [comment](https://github.com/workbenchdev/Workbench/issues/929#issuecomment-2073996633) https://github.com/workbenchdev/Workbench/issues/929#issuecomment-2073996633

> I would like to know the possibility of adding a keyboard shortcut to switch between the two (XML and blueprint)

> My current workflow innvolves desiging the UI using blueprint, and then copying the XML code into a .ui file.

Here is a draft of what I think could work. This is still a draft incase there are things i missed or need to change.

- `<Control><Shift>B` is for blueprints
- `<Control><Shift>X` is for XML

I have not done extensive testing on this feature (I do plan to use my fork for the coming few days to test things out) but it does seem to serve my workflow nicely. 