### PR TITLE
Fix gst-plugin-gtk4 not being picked up

### DIFF
--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -22,7 +22,8 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--socket=pulseaudio"
+    "--socket=pulseaudio",
+    "--env=GST_PLUGIN_PATH=/app/lib64/gstreamer-1.0"
   ],
   "cleanup": [
     "#/include",


### PR DESCRIPTION
Not sure what's changed, but `gtk4paintablesink` doesn't get picked up automatically anymore. This PR makes GStreamer able to see it.

Without this, these demos are currently broken.

- Camera
- Screencast