### PR TITLE
Fix code search close button behavior

### DIFF
--- a/src/widgets/CodeFind.js
+++ b/src/widgets/CodeFind.js
@@ -72,7 +72,7 @@ class Search extends Gtk.Revealer {
   }
 
   onClose() {
-    this.reveal_child = false;
+    this.#endSearch(true);
   }
 
   #addControllers() {


### PR DESCRIPTION
Fixes #959 

Clear the highlights in the code and remember the last searched word