### PR TITLE
GNOME 47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL:=/bin/bash -O globstar
 
 setup:
 	flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//47 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//24.08 org.freedesktop.Sdk.Extension.vala//24.08 org.freedesktop.Sdk.Extension.llvm18//24.08 org.freedesktop.Sdk.Extension.node20//24.08 org.freedesktop.Sdk.Extension.typescript//24.08
+	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//47 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//24.08 org.freedesktop.Sdk.Extension.vala//24.08 org.freedesktop.Sdk.Extension.llvm18//24.08 org.freedesktop.Sdk.Extension.node20//24.08 #org.freedesktop.Sdk.Extension.typescript//24.08
 # flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 # flatpak remote-add --user --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
 # flatpak install --or-update --user --noninteractive gnome-nightly org.gnome.Sdk//master

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,8 @@ SHELL:=/bin/bash -O globstar
 
 setup:
 	flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//46 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08 org.freedesktop.Sdk.Extension.llvm18//23.08 org.freedesktop.Sdk.Extension.node18//23.08 org.freedesktop.Sdk.Extension.typescript//23.08
+	flatpak install --or-update --user --noninteractive flathub org.gnome.Sdk//47 org.flatpak.Builder org.freedesktop.Sdk.Extension.rust-stable//24.08 org.freedesktop.Sdk.Extension.vala//24.08 org.freedesktop.Sdk.Extension.llvm18//24.08 org.freedesktop.Sdk.Extension.node20//24.08 org.freedesktop.Sdk.Extension.typescript//24.08
 # flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-# flatpak install --or-update --user --noninteractive flathub-beta org.freedesktop.Sdk.Extension.rust-stable//24.08beta org.freedesktop.Sdk.Extension.vala//24.08beta org.freedesktop.Sdk.Extension.llvm18//24.08beta org.freedesktop.Sdk.Extension.node18//24.08beta org.freedesktop.Sdk.Extension.typescript//24.08beta
 # flatpak remote-add --user --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
 # flatpak install --or-update --user --noninteractive gnome-nightly org.gnome.Sdk//master
 	git submodule update --init
@@ -70,14 +69,14 @@ ci: setup build test
 # make sure to test without the sdk extensions installed
 sandbox: setup
 	flatpak run org.flatpak.Builder --ccache --user --install --force-clean flatpak build-aux/re.sonny.Workbench.Devel.json
-# flatpak remove --noninteractive org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08 org.freedesktop.Sdk.Extension.llvm18//23.08
+# flatpak remove --noninteractive org.freedesktop.Sdk.Extension.rust-stable//24.08 org.freedesktop.Sdk.Extension.vala//24.08 org.freedesktop.Sdk.Extension.llvm18//24.08
 	flatpak run --command="bash" re.sonny.Workbench.Devel
 
 flatpak:
 	flatpak run org.flatpak.Builder --ccache --force-clean flatpak build-aux/re.sonny.Workbench.Devel.json
 # This is what Flathub does - consider moving to lint
 	flatpak run --env=G_DEBUG=fatal-criticals --command=appstream-util org.flatpak.Builder validate flatpak/files/share/appdata/re.sonny.Workbench.Devel.appdata.xml
-	flatpak run --command="desktop-file-validate" --filesystem=host:ro org.freedesktop.Sdk//23.08 flatpak/files/share/applications/re.sonny.Workbench.Devel.desktop
+	flatpak run --command="desktop-file-validate" --filesystem=host:ro org.freedesktop.Sdk//24.08 flatpak/files/share/applications/re.sonny.Workbench.Devel.desktop
 # appstreamcli validate --override=release-time-missing=info /path/to/your/app.metainfo.xml
 	flatpak run org.flatpak.Builder --run flatpak build-aux/re.sonny.Workbench.Devel.json bash
 

--- a/build-aux/modules/GTKCssLanguageServer.json
+++ b/build-aux/modules/GTKCssLanguageServer.json
@@ -12,7 +12,11 @@
   "modules": [
     {
       "name": "jsonrpc-glib",
-      "config-opts": ["--buildtype=release", "-Denable_tests=false"],
+      "config-opts": [
+        "--libdir=/app/lib",
+        "--buildtype=release",
+        "-Denable_tests=false"
+      ],
       "buildsystem": "meson",
       "sources": [
         {

--- a/build-aux/modules/biome.json
+++ b/build-aux/modules/biome.json
@@ -7,15 +7,15 @@
       "type": "file",
       "dest-filename": "biome",
       "only-arches": ["aarch64"],
-      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.8.3/biome-linux-arm64",
-      "sha256": "d134e89f6f4fc29d32c8101efb074969ac263ebdb0303e07039e3735002c6a2d"
+      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.2/biome-linux-arm64",
+      "sha256": "b4b88a36487e5b6c7b34fdc5351f4beb57ce7d88497f57fd3474c64413aabf78"
     },
     {
       "type": "file",
       "dest-filename": "biome",
       "only-arches": ["x86_64"],
-      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.8.3/biome-linux-x64",
-      "sha256": "5495f2f69edd94e9f26ed1adb9ed8023d7c143c3cc6f275f90abdded612217e4"
+      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.2/biome-linux-x64",
+      "sha256": "e17bb3d15fc192aa767ae7691302f4fd239e80ceaace4c3238857b9da0f43902"
     }
   ]
 }

--- a/build-aux/modules/biome.json
+++ b/build-aux/modules/biome.json
@@ -1,0 +1,21 @@
+{
+  "name": "biome",
+  "buildsystem": "simple",
+  "build-commands": ["chmod +x biome", "cp biome /app/bin/biome"],
+  "sources": [
+    {
+      "type": "file",
+      "dest-filename": "biome",
+      "only-arches": ["aarch64"],
+      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.8.3/biome-linux-arm64",
+      "sha256": "d134e89f6f4fc29d32c8101efb074969ac263ebdb0303e07039e3735002c6a2d"
+    },
+    {
+      "type": "file",
+      "dest-filename": "biome",
+      "only-arches": ["x86_64"],
+      "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.8.3/biome-linux-x64",
+      "sha256": "5495f2f69edd94e9f26ed1adb9ed8023d7c143c3cc6f275f90abdded612217e4"
+    }
+  ]
+}

--- a/build-aux/modules/gom.json
+++ b/build-aux/modules/gom.json
@@ -1,6 +1,7 @@
 {
   "name": "gom",
   "buildsystem": "meson",
+  "config-opts": ["--libdir=/app/lib", "-Denable-gtk-doc=false"],
   "sources": [
     {
       "type": "archive",

--- a/build-aux/modules/gst-plugin-gtk4-sources.json
+++ b/build-aux/modules/gst-plugin-gtk4-sources.json
@@ -67,14 +67,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/bitflags/bitflags-2.5.0.crate",
-    "sha256": "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1",
-    "dest": "cargo/vendor/bitflags-2.5.0"
+    "url": "https://static.crates.io/crates/bitflags/bitflags-2.6.0.crate",
+    "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+    "dest": "cargo/vendor/bitflags-2.6.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1\", \"files\": {}}",
-    "dest": "cargo/vendor/bitflags-2.5.0",
+    "contents": "{\"package\": \"b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de\", \"files\": {}}",
+    "dest": "cargo/vendor/bitflags-2.6.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -93,53 +93,53 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.19.4.crate",
-    "sha256": "b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562",
-    "dest": "cargo/vendor/cairo-rs-0.19.4"
+    "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.20.1.crate",
+    "sha256": "e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69",
+    "dest": "cargo/vendor/cairo-rs-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562\", \"files\": {}}",
-    "dest": "cargo/vendor/cairo-rs-0.19.4",
+    "contents": "{\"package\": \"e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69\", \"files\": {}}",
+    "dest": "cargo/vendor/cairo-rs-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.19.2.crate",
-    "sha256": "fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64",
-    "dest": "cargo/vendor/cairo-sys-rs-0.19.2"
+    "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.20.0.crate",
+    "sha256": "428290f914b9b86089f60f5d8a9f6e440508e1bcff23b25afd51502b0a2da88f",
+    "dest": "cargo/vendor/cairo-sys-rs-0.20.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64\", \"files\": {}}",
-    "dest": "cargo/vendor/cairo-sys-rs-0.19.2",
+    "contents": "{\"package\": \"428290f914b9b86089f60f5d8a9f6e440508e1bcff23b25afd51502b0a2da88f\", \"files\": {}}",
+    "dest": "cargo/vendor/cairo-sys-rs-0.20.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/cc/cc-1.0.99.crate",
-    "sha256": "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695",
-    "dest": "cargo/vendor/cc-1.0.99"
+    "url": "https://static.crates.io/crates/cc/cc-1.1.15.crate",
+    "sha256": "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6",
+    "dest": "cargo/vendor/cc-1.1.15"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695\", \"files\": {}}",
-    "dest": "cargo/vendor/cc-1.0.99",
+    "contents": "{\"package\": \"57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6\", \"files\": {}}",
+    "dest": "cargo/vendor/cc-1.1.15",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.8.crate",
-    "sha256": "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02",
-    "dest": "cargo/vendor/cfg-expr-0.15.8"
+    "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.16.0.crate",
+    "sha256": "345c78335be0624ed29012dc10c49102196c6882c12dde65d9f35b02da2aada8",
+    "dest": "cargo/vendor/cfg-expr-0.16.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
-    "dest": "cargo/vendor/cfg-expr-0.15.8",
+    "contents": "{\"package\": \"345c78335be0624ed29012dc10c49102196c6882c12dde65d9f35b02da2aada8\", \"files\": {}}",
+    "dest": "cargo/vendor/cfg-expr-0.16.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -184,14 +184,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.6.crate",
-    "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f",
-    "dest": "cargo/vendor/core-foundation-sys-0.8.6"
+    "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
+    "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
+    "dest": "cargo/vendor/core-foundation-sys-0.8.7"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f\", \"files\": {}}",
-    "dest": "cargo/vendor/core-foundation-sys-0.8.6",
+    "contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
+    "dest": "cargo/vendor/core-foundation-sys-0.8.7",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -210,14 +210,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/either/either-1.12.0.crate",
-    "sha256": "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b",
-    "dest": "cargo/vendor/either-1.12.0"
+    "url": "https://static.crates.io/crates/either/either-1.13.0.crate",
+    "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+    "dest": "cargo/vendor/either-1.13.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b\", \"files\": {}}",
-    "dest": "cargo/vendor/either-1.12.0",
+    "contents": "{\"package\": \"60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0\", \"files\": {}}",
+    "dest": "cargo/vendor/either-1.13.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -366,261 +366,261 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.19.8.crate",
-    "sha256": "624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699",
-    "dest": "cargo/vendor/gdk-pixbuf-0.19.8"
+    "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.20.1.crate",
+    "sha256": "8730751991b97419fc3f0c2dca2c9e45b48edf46e48e0f965964ecf33889812f",
+    "dest": "cargo/vendor/gdk-pixbuf-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk-pixbuf-0.19.8",
+    "contents": "{\"package\": \"8730751991b97419fc3f0c2dca2c9e45b48edf46e48e0f965964ecf33889812f\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk-pixbuf-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.19.8.crate",
-    "sha256": "4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379",
-    "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8"
+    "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.20.1.crate",
+    "sha256": "1ffbf649fd5b1c8c0f0feeb015b7533c3ef92da2887fb95ddd338bc2b1644a7c",
+    "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8",
+    "contents": "{\"package\": \"1ffbf649fd5b1c8c0f0feeb015b7533c3ef92da2887fb95ddd338bc2b1644a7c\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4/gdk4-0.8.2.crate",
-    "sha256": "db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07",
-    "dest": "cargo/vendor/gdk4-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4/gdk4-0.9.0.crate",
+    "sha256": "4b7d7237c1487ed4b300aac7744efcbf1319e12d60d7afcd6f505414bd5b5dea",
+    "dest": "cargo/vendor/gdk4-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-0.8.2",
+    "contents": "{\"package\": \"4b7d7237c1487ed4b300aac7744efcbf1319e12d60d7afcd6f505414bd5b5dea\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.8.2.crate",
-    "sha256": "c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd",
-    "dest": "cargo/vendor/gdk4-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.9.0.crate",
+    "sha256": "a67576c8ec012156d7f680e201a807b4432a77babb3157e0555e990ab6bcd878",
+    "dest": "cargo/vendor/gdk4-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-sys-0.8.2",
+    "contents": "{\"package\": \"a67576c8ec012156d7f680e201a807b4432a77babb3157e0555e990ab6bcd878\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-wayland/gdk4-wayland-0.8.2.crate",
-    "sha256": "f620a0ecbe4c574e3fec6bef6bebcefe19cb1b9a81569245ca4503c95f9b1371",
-    "dest": "cargo/vendor/gdk4-wayland-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-wayland/gdk4-wayland-0.9.1.crate",
+    "sha256": "d48ff9cbd61a1a87b36faed4793d0d8603a2cd8db38f5df7800448ddc1a3d462",
+    "dest": "cargo/vendor/gdk4-wayland-0.9.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"f620a0ecbe4c574e3fec6bef6bebcefe19cb1b9a81569245ca4503c95f9b1371\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-wayland-0.8.2",
+    "contents": "{\"package\": \"d48ff9cbd61a1a87b36faed4793d0d8603a2cd8db38f5df7800448ddc1a3d462\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-wayland-0.9.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-wayland-sys/gdk4-wayland-sys-0.8.2.crate",
-    "sha256": "7a5fd3927c917184b0e8712624eebabdc7f0909b645d468c825f8ec627e61803",
-    "dest": "cargo/vendor/gdk4-wayland-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-wayland-sys/gdk4-wayland-sys-0.9.0.crate",
+    "sha256": "23295b2ecafae572224a382b876b0bdc0fed947da63b51edebc8798288002048",
+    "dest": "cargo/vendor/gdk4-wayland-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"7a5fd3927c917184b0e8712624eebabdc7f0909b645d468c825f8ec627e61803\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-wayland-sys-0.8.2",
+    "contents": "{\"package\": \"23295b2ecafae572224a382b876b0bdc0fed947da63b51edebc8798288002048\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-wayland-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-win32/gdk4-win32-0.8.2.crate",
-    "sha256": "3294d0d08b179198a01ac2623786e6227e3d7a98e042e26e4d020f31ba8fac41",
-    "dest": "cargo/vendor/gdk4-win32-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-win32/gdk4-win32-0.9.0.crate",
+    "sha256": "05afbcc8165b10f9143d2c4e4a589fce3a5071c6b20d75dd40704266d6eb4bb4",
+    "dest": "cargo/vendor/gdk4-win32-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"3294d0d08b179198a01ac2623786e6227e3d7a98e042e26e4d020f31ba8fac41\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-win32-0.8.2",
+    "contents": "{\"package\": \"05afbcc8165b10f9143d2c4e4a589fce3a5071c6b20d75dd40704266d6eb4bb4\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-win32-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-win32-sys/gdk4-win32-sys-0.8.2.crate",
-    "sha256": "6682a82d3a1616fbe17a9a757528bd3ef0ede3eab7487f0ecf6ed2a499de117d",
-    "dest": "cargo/vendor/gdk4-win32-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-win32-sys/gdk4-win32-sys-0.9.0.crate",
+    "sha256": "198c0604ceb45732c76b1fdb696d92b99400ea3a1c549fc5e40f4d79f8033205",
+    "dest": "cargo/vendor/gdk4-win32-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"6682a82d3a1616fbe17a9a757528bd3ef0ede3eab7487f0ecf6ed2a499de117d\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-win32-sys-0.8.2",
+    "contents": "{\"package\": \"198c0604ceb45732c76b1fdb696d92b99400ea3a1c549fc5e40f4d79f8033205\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-win32-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-x11/gdk4-x11-0.8.2.crate",
-    "sha256": "ec6da3e3527007c14b27ddafe19496c49696a2a74dccb6ab75ba58dfa478b7ab",
-    "dest": "cargo/vendor/gdk4-x11-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-x11/gdk4-x11-0.9.0.crate",
+    "sha256": "c4b89c2149f74668d630279559fb5e2b4f11a77124b73d04518cc344854cd626",
+    "dest": "cargo/vendor/gdk4-x11-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"ec6da3e3527007c14b27ddafe19496c49696a2a74dccb6ab75ba58dfa478b7ab\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-x11-0.8.2",
+    "contents": "{\"package\": \"c4b89c2149f74668d630279559fb5e2b4f11a77124b73d04518cc344854cd626\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-x11-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gdk4-x11-sys/gdk4-x11-sys-0.8.2.crate",
-    "sha256": "0bb4e987ec77b7b2fb72c0943ccbec5c3834d9d7165fe762af8ff2414f0ae23d",
-    "dest": "cargo/vendor/gdk4-x11-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gdk4-x11-sys/gdk4-x11-sys-0.9.0.crate",
+    "sha256": "a186f565940124ebd6c1c97e9eb0909e2d19a33ccd3eebed4ff32ebda766207d",
+    "dest": "cargo/vendor/gdk4-x11-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"0bb4e987ec77b7b2fb72c0943ccbec5c3834d9d7165fe762af8ff2414f0ae23d\", \"files\": {}}",
-    "dest": "cargo/vendor/gdk4-x11-sys-0.8.2",
+    "contents": "{\"package\": \"a186f565940124ebd6c1c97e9eb0909e2d19a33ccd3eebed4ff32ebda766207d\", \"files\": {}}",
+    "dest": "cargo/vendor/gdk4-x11-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gio/gio-0.19.8.crate",
-    "sha256": "4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe",
-    "dest": "cargo/vendor/gio-0.19.8"
+    "url": "https://static.crates.io/crates/gio/gio-0.20.1.crate",
+    "sha256": "dcacaa37401cad0a95aadd266bc39c72a131d454fc012f6dfd217f891d76cc52",
+    "dest": "cargo/vendor/gio-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe\", \"files\": {}}",
-    "dest": "cargo/vendor/gio-0.19.8",
+    "contents": "{\"package\": \"dcacaa37401cad0a95aadd266bc39c72a131d454fc012f6dfd217f891d76cc52\", \"files\": {}}",
+    "dest": "cargo/vendor/gio-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.19.8.crate",
-    "sha256": "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef",
-    "dest": "cargo/vendor/gio-sys-0.19.8"
+    "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.1.crate",
+    "sha256": "5237611e97e9b86ab5768adc3eef853ae713ea797aa3835404acdfacffc9fb38",
+    "dest": "cargo/vendor/gio-sys-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef\", \"files\": {}}",
-    "dest": "cargo/vendor/gio-sys-0.19.8",
+    "contents": "{\"package\": \"5237611e97e9b86ab5768adc3eef853ae713ea797aa3835404acdfacffc9fb38\", \"files\": {}}",
+    "dest": "cargo/vendor/gio-sys-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/glib/glib-0.19.8.crate",
-    "sha256": "b664491bc77ab55daa6714a592cdbe1a55e28abec09cb50e87689b90de456ff4",
-    "dest": "cargo/vendor/glib-0.19.8"
+    "url": "https://static.crates.io/crates/glib/glib-0.20.2.crate",
+    "sha256": "9c1ea829497810f8e87f5ee6d05c4879af641704add879e6b6080607cceeefe4",
+    "dest": "cargo/vendor/glib-0.20.2"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"b664491bc77ab55daa6714a592cdbe1a55e28abec09cb50e87689b90de456ff4\", \"files\": {}}",
-    "dest": "cargo/vendor/glib-0.19.8",
+    "contents": "{\"package\": \"9c1ea829497810f8e87f5ee6d05c4879af641704add879e6b6080607cceeefe4\", \"files\": {}}",
+    "dest": "cargo/vendor/glib-0.20.2",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.19.8.crate",
-    "sha256": "1d405205a405182f95e637710850a8e82f25ba01fdd6baebc82dabeaf0883376",
-    "dest": "cargo/vendor/glib-macros-0.19.8"
+    "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.2.crate",
+    "sha256": "951aa19c5e89555c0ca5e94ee874b24b2594ece8412b387bd84ee3266b8a3ea0",
+    "dest": "cargo/vendor/glib-macros-0.20.2"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"1d405205a405182f95e637710850a8e82f25ba01fdd6baebc82dabeaf0883376\", \"files\": {}}",
-    "dest": "cargo/vendor/glib-macros-0.19.8",
+    "contents": "{\"package\": \"951aa19c5e89555c0ca5e94ee874b24b2594ece8412b387bd84ee3266b8a3ea0\", \"files\": {}}",
+    "dest": "cargo/vendor/glib-macros-0.20.2",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.19.8.crate",
-    "sha256": "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5",
-    "dest": "cargo/vendor/glib-sys-0.19.8"
+    "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.2.crate",
+    "sha256": "92eee4531c1c9abba945d19378b205031b5890e1f99c319ba0503b6e0c06a163",
+    "dest": "cargo/vendor/glib-sys-0.20.2"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5\", \"files\": {}}",
-    "dest": "cargo/vendor/glib-sys-0.19.8",
+    "contents": "{\"package\": \"92eee4531c1c9abba945d19378b205031b5890e1f99c319ba0503b6e0c06a163\", \"files\": {}}",
+    "dest": "cargo/vendor/glib-sys-0.20.2",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.19.8.crate",
-    "sha256": "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e",
-    "dest": "cargo/vendor/gobject-sys-0.19.8"
+    "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.1.crate",
+    "sha256": "fa3d1dcd8a1eb2e7c22be3d5e792b14b186f3524f79b25631730f9a8c169d49a",
+    "dest": "cargo/vendor/gobject-sys-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e\", \"files\": {}}",
-    "dest": "cargo/vendor/gobject-sys-0.19.8",
+    "contents": "{\"package\": \"fa3d1dcd8a1eb2e7c22be3d5e792b14b186f3524f79b25631730f9a8c169d49a\", \"files\": {}}",
+    "dest": "cargo/vendor/gobject-sys-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.19.8.crate",
-    "sha256": "f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf",
-    "dest": "cargo/vendor/graphene-rs-0.19.8"
+    "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.20.1.crate",
+    "sha256": "80aac87f74e81c0e13433e892a047237abdc37945c86887f5eed905038356e69",
+    "dest": "cargo/vendor/graphene-rs-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf\", \"files\": {}}",
-    "dest": "cargo/vendor/graphene-rs-0.19.8",
+    "contents": "{\"package\": \"80aac87f74e81c0e13433e892a047237abdc37945c86887f5eed905038356e69\", \"files\": {}}",
+    "dest": "cargo/vendor/graphene-rs-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.19.8.crate",
-    "sha256": "2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05",
-    "dest": "cargo/vendor/graphene-sys-0.19.8"
+    "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.20.1.crate",
+    "sha256": "cc2f91ecd32989efad60326cc20a8fb252bd2852239a08e4e70cde8c100de9ca",
+    "dest": "cargo/vendor/graphene-sys-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05\", \"files\": {}}",
-    "dest": "cargo/vendor/graphene-sys-0.19.8",
+    "contents": "{\"package\": \"cc2f91ecd32989efad60326cc20a8fb252bd2852239a08e4e70cde8c100de9ca\", \"files\": {}}",
+    "dest": "cargo/vendor/graphene-sys-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gsk4/gsk4-0.8.2.crate",
-    "sha256": "7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be",
-    "dest": "cargo/vendor/gsk4-0.8.2"
+    "url": "https://static.crates.io/crates/gsk4/gsk4-0.9.0.crate",
+    "sha256": "1f3cf2091e1af185b347b3450817d93dea6fe435df7abd4c2cd7fb5bcb4cfda8",
+    "dest": "cargo/vendor/gsk4-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be\", \"files\": {}}",
-    "dest": "cargo/vendor/gsk4-0.8.2",
+    "contents": "{\"package\": \"1f3cf2091e1af185b347b3450817d93dea6fe435df7abd4c2cd7fb5bcb4cfda8\", \"files\": {}}",
+    "dest": "cargo/vendor/gsk4-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.8.2.crate",
-    "sha256": "23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc",
-    "dest": "cargo/vendor/gsk4-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.9.0.crate",
+    "sha256": "6aa69614a26d8760c186c3690f1b0fbb917572ca23ef83137445770ceddf8cde",
+    "dest": "cargo/vendor/gsk4-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc\", \"files\": {}}",
-    "dest": "cargo/vendor/gsk4-sys-0.8.2",
+    "contents": "{\"package\": \"6aa69614a26d8760c186c3690f1b0fbb917572ca23ef83137445770ceddf8cde\", \"files\": {}}",
+    "dest": "cargo/vendor/gsk4-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -639,248 +639,248 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer/gstreamer-0.22.6.crate",
-    "sha256": "080daaf35d22367a398aefd032af80cc36238c76fac7b8822894f5e5be073795",
-    "dest": "cargo/vendor/gstreamer-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer/gstreamer-0.23.1.crate",
+    "sha256": "683e15f8cc3a1a2646d9fe2181a58b7abb4c166256d8d15cce368e420c741140",
+    "dest": "cargo/vendor/gstreamer-0.23.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"080daaf35d22367a398aefd032af80cc36238c76fac7b8822894f5e5be073795\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-0.22.6",
+    "contents": "{\"package\": \"683e15f8cc3a1a2646d9fe2181a58b7abb4c166256d8d15cce368e420c741140\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-0.23.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-allocators/gstreamer-allocators-0.22.6.crate",
-    "sha256": "1a53239735ec0376659ec082343225cd0e1a53f7f2ee318aec32adc696e31fe6",
-    "dest": "cargo/vendor/gstreamer-allocators-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-allocators/gstreamer-allocators-0.23.0.crate",
+    "sha256": "cab5a724c4af4f18bb5cbe8b03adc188c3254f6a6acfc981ec28e00cf2f4f088",
+    "dest": "cargo/vendor/gstreamer-allocators-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"1a53239735ec0376659ec082343225cd0e1a53f7f2ee318aec32adc696e31fe6\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-allocators-0.22.6",
+    "contents": "{\"package\": \"cab5a724c4af4f18bb5cbe8b03adc188c3254f6a6acfc981ec28e00cf2f4f088\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-allocators-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-allocators-sys/gstreamer-allocators-sys-0.22.6.crate",
-    "sha256": "9b651aa05affa0c57dbb5c85b8a0729a10c2aa412bd9ef14d782a39934835e5c",
-    "dest": "cargo/vendor/gstreamer-allocators-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-allocators-sys/gstreamer-allocators-sys-0.23.0.crate",
+    "sha256": "05c49cf4d560666db1d83afa3aa3200d6dff3675ab672746260514e8583f4b68",
+    "dest": "cargo/vendor/gstreamer-allocators-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"9b651aa05affa0c57dbb5c85b8a0729a10c2aa412bd9ef14d782a39934835e5c\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-allocators-sys-0.22.6",
+    "contents": "{\"package\": \"05c49cf4d560666db1d83afa3aa3200d6dff3675ab672746260514e8583f4b68\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-allocators-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-base/gstreamer-base-0.22.6.crate",
-    "sha256": "39d55668b23fc69f1843daa42b43d289c00fe38e9586c5453b134783d2dd75a3",
-    "dest": "cargo/vendor/gstreamer-base-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-base/gstreamer-base-0.23.1.crate",
+    "sha256": "ed5d73cb5cbf229c8904fba5ff93b1863f186bccc062064c1b2a9000750cc06e",
+    "dest": "cargo/vendor/gstreamer-base-0.23.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"39d55668b23fc69f1843daa42b43d289c00fe38e9586c5453b134783d2dd75a3\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-base-0.22.6",
+    "contents": "{\"package\": \"ed5d73cb5cbf229c8904fba5ff93b1863f186bccc062064c1b2a9000750cc06e\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-base-0.23.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-base-sys/gstreamer-base-sys-0.22.6.crate",
-    "sha256": "5448abb00c197e3ad306710293bf757303cbeab4036b5ccad21c7642b8bf00c9",
-    "dest": "cargo/vendor/gstreamer-base-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-base-sys/gstreamer-base-sys-0.23.0.crate",
+    "sha256": "4a6643ef963c636b8022adc93aa19eac6f356bd174a187c499339fc5d64c1e05",
+    "dest": "cargo/vendor/gstreamer-base-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"5448abb00c197e3ad306710293bf757303cbeab4036b5ccad21c7642b8bf00c9\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-base-sys-0.22.6",
+    "contents": "{\"package\": \"4a6643ef963c636b8022adc93aa19eac6f356bd174a187c499339fc5d64c1e05\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-base-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl/gstreamer-gl-0.22.6.crate",
-    "sha256": "2776369ce07de81b1e6f52786caec898db5be5d4678a8104e8fcbffdae68332d",
-    "dest": "cargo/vendor/gstreamer-gl-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl/gstreamer-gl-0.23.0.crate",
+    "sha256": "cfe28e4b7c72022958add8a3d86e7293ff227a5086c426731b5ec5a15ffbc759",
+    "dest": "cargo/vendor/gstreamer-gl-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"2776369ce07de81b1e6f52786caec898db5be5d4678a8104e8fcbffdae68332d\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-0.22.6",
+    "contents": "{\"package\": \"cfe28e4b7c72022958add8a3d86e7293ff227a5086c426731b5ec5a15ffbc759\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-egl/gstreamer-gl-egl-0.22.6.crate",
-    "sha256": "be51a7ceaeabf411ba01a2de5af163ea2b8d79f157d0d924b4682fd217182c15",
-    "dest": "cargo/vendor/gstreamer-gl-egl-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-egl/gstreamer-gl-egl-0.23.0.crate",
+    "sha256": "e643d4810c4fab58eecf494504e304bd67fceabce2635dbc238302c904fb2b65",
+    "dest": "cargo/vendor/gstreamer-gl-egl-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"be51a7ceaeabf411ba01a2de5af163ea2b8d79f157d0d924b4682fd217182c15\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-egl-0.22.6",
+    "contents": "{\"package\": \"e643d4810c4fab58eecf494504e304bd67fceabce2635dbc238302c904fb2b65\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-egl-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-egl-sys/gstreamer-gl-egl-sys-0.22.6.crate",
-    "sha256": "45bc9d114f161ec27822c203f28e43c88b6523f31cbde29b4cb8d8378a3825a4",
-    "dest": "cargo/vendor/gstreamer-gl-egl-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-egl-sys/gstreamer-gl-egl-sys-0.23.0.crate",
+    "sha256": "f5b75c95d1c4ddb23018e01db2103c1012c66bf35771fae00d5cce6270cb5cbe",
+    "dest": "cargo/vendor/gstreamer-gl-egl-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"45bc9d114f161ec27822c203f28e43c88b6523f31cbde29b4cb8d8378a3825a4\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-egl-sys-0.22.6",
+    "contents": "{\"package\": \"f5b75c95d1c4ddb23018e01db2103c1012c66bf35771fae00d5cce6270cb5cbe\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-egl-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-sys/gstreamer-gl-sys-0.22.6.crate",
-    "sha256": "050a2cf158354bd5633079baf73d12767a5c90efc6377b4f9507aca082734286",
-    "dest": "cargo/vendor/gstreamer-gl-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-sys/gstreamer-gl-sys-0.23.0.crate",
+    "sha256": "2bc2ff7c20ae47c4a80f42a67d85d6889a5fad3bc2385aec6dc9b58795920c5b",
+    "dest": "cargo/vendor/gstreamer-gl-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"050a2cf158354bd5633079baf73d12767a5c90efc6377b4f9507aca082734286\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-sys-0.22.6",
+    "contents": "{\"package\": \"2bc2ff7c20ae47c4a80f42a67d85d6889a5fad3bc2385aec6dc9b58795920c5b\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-wayland/gstreamer-gl-wayland-0.22.6.crate",
-    "sha256": "1ed320047a5b5f33eb7011fecd57355eaefece278a244e16bfde475b1b268b68",
-    "dest": "cargo/vendor/gstreamer-gl-wayland-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-wayland/gstreamer-gl-wayland-0.23.0.crate",
+    "sha256": "4bfdf826d8cd3963d4bf2b195f9c5e83cec326320c7919710c5eea65c766a86a",
+    "dest": "cargo/vendor/gstreamer-gl-wayland-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"1ed320047a5b5f33eb7011fecd57355eaefece278a244e16bfde475b1b268b68\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-wayland-0.22.6",
+    "contents": "{\"package\": \"4bfdf826d8cd3963d4bf2b195f9c5e83cec326320c7919710c5eea65c766a86a\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-wayland-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-wayland-sys/gstreamer-gl-wayland-sys-0.22.6.crate",
-    "sha256": "2c0fcf9857b41dd4e96dba723edce306853d5a166a5165f7d15a1be672be6c3d",
-    "dest": "cargo/vendor/gstreamer-gl-wayland-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-wayland-sys/gstreamer-gl-wayland-sys-0.23.0.crate",
+    "sha256": "558b96fbba96b96ced4cea976fcb159f0aef66c963ca3507cc04b9f9c5e57c35",
+    "dest": "cargo/vendor/gstreamer-gl-wayland-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"2c0fcf9857b41dd4e96dba723edce306853d5a166a5165f7d15a1be672be6c3d\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-wayland-sys-0.22.6",
+    "contents": "{\"package\": \"558b96fbba96b96ced4cea976fcb159f0aef66c963ca3507cc04b9f9c5e57c35\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-wayland-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-x11/gstreamer-gl-x11-0.22.6.crate",
-    "sha256": "e4867cfe9333b04ee14672001e914ea995707a8b02d7b12c1b6f3e9f4a5c4f0d",
-    "dest": "cargo/vendor/gstreamer-gl-x11-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-x11/gstreamer-gl-x11-0.23.0.crate",
+    "sha256": "a09d7356fed130cec502fb4d7059e830a28fcbe22495f047e3d58333981aa875",
+    "dest": "cargo/vendor/gstreamer-gl-x11-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"e4867cfe9333b04ee14672001e914ea995707a8b02d7b12c1b6f3e9f4a5c4f0d\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-x11-0.22.6",
+    "contents": "{\"package\": \"a09d7356fed130cec502fb4d7059e830a28fcbe22495f047e3d58333981aa875\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-x11-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-gl-x11-sys/gstreamer-gl-x11-sys-0.22.6.crate",
-    "sha256": "c628a2a3d216df2f85d37923f65a4e0fdafe4652f7cd06c9432f8c8ce8199aa9",
-    "dest": "cargo/vendor/gstreamer-gl-x11-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-gl-x11-sys/gstreamer-gl-x11-sys-0.23.0.crate",
+    "sha256": "442f9e3a4c979fb868bdf3c9249bf669370c4a463a3408f940592e15a7eea958",
+    "dest": "cargo/vendor/gstreamer-gl-x11-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"c628a2a3d216df2f85d37923f65a4e0fdafe4652f7cd06c9432f8c8ce8199aa9\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-gl-x11-sys-0.22.6",
+    "contents": "{\"package\": \"442f9e3a4c979fb868bdf3c9249bf669370c4a463a3408f940592e15a7eea958\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-gl-x11-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-sys/gstreamer-sys-0.22.6.crate",
-    "sha256": "71f147e7c6bc9313d5569eb15da61f6f64026ec69791922749de230583a07286",
-    "dest": "cargo/vendor/gstreamer-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-sys/gstreamer-sys-0.23.0.crate",
+    "sha256": "d9c9005b55dd2b1784645963c1ec409f9d420a56f6348d0ae69c2eaff584bcc3",
+    "dest": "cargo/vendor/gstreamer-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"71f147e7c6bc9313d5569eb15da61f6f64026ec69791922749de230583a07286\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-sys-0.22.6",
+    "contents": "{\"package\": \"d9c9005b55dd2b1784645963c1ec409f9d420a56f6348d0ae69c2eaff584bcc3\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-video/gstreamer-video-0.22.6.crate",
-    "sha256": "25acba301f86b02584a642de0f224317be2bd0ceec3acda49a0ef111cbced98c",
-    "dest": "cargo/vendor/gstreamer-video-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-video/gstreamer-video-0.23.0.crate",
+    "sha256": "57332bca1ae7825a53fe57d993b63389f132d335aed691ac76f0ffe4304548e3",
+    "dest": "cargo/vendor/gstreamer-video-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"25acba301f86b02584a642de0f224317be2bd0ceec3acda49a0ef111cbced98c\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-video-0.22.6",
+    "contents": "{\"package\": \"57332bca1ae7825a53fe57d993b63389f132d335aed691ac76f0ffe4304548e3\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-video-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gstreamer-video-sys/gstreamer-video-sys-0.22.6.crate",
-    "sha256": "f2ec210495f94cabaa45d08003081b550095c2d4ab12d5320f64856a91f3f01c",
-    "dest": "cargo/vendor/gstreamer-video-sys-0.22.6"
+    "url": "https://static.crates.io/crates/gstreamer-video-sys/gstreamer-video-sys-0.23.0.crate",
+    "sha256": "0f5c334d143384e8dc714af948c2e5d7d12cb588fdcfb56f3bf37c24daf350ef",
+    "dest": "cargo/vendor/gstreamer-video-sys-0.23.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"f2ec210495f94cabaa45d08003081b550095c2d4ab12d5320f64856a91f3f01c\", \"files\": {}}",
-    "dest": "cargo/vendor/gstreamer-video-sys-0.22.6",
+    "contents": "{\"package\": \"0f5c334d143384e8dc714af948c2e5d7d12cb588fdcfb56f3bf37c24daf350ef\", \"files\": {}}",
+    "dest": "cargo/vendor/gstreamer-video-sys-0.23.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gtk4/gtk4-0.8.2.crate",
-    "sha256": "b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab",
-    "dest": "cargo/vendor/gtk4-0.8.2"
+    "url": "https://static.crates.io/crates/gtk4/gtk4-0.9.1.crate",
+    "sha256": "f4fe572bf318e5dbc6f5a2f8a25d853f1ae3f42768c0b08af6ca20a18f4057e1",
+    "dest": "cargo/vendor/gtk4-0.9.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab\", \"files\": {}}",
-    "dest": "cargo/vendor/gtk4-0.8.2",
+    "contents": "{\"package\": \"f4fe572bf318e5dbc6f5a2f8a25d853f1ae3f42768c0b08af6ca20a18f4057e1\", \"files\": {}}",
+    "dest": "cargo/vendor/gtk4-0.9.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.8.2.crate",
-    "sha256": "ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408",
-    "dest": "cargo/vendor/gtk4-macros-0.8.2"
+    "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.9.1.crate",
+    "sha256": "e9e7b362c8fccd2712297903717d65d30defdab2b509bc9d209cbe5ffb9fabaf",
+    "dest": "cargo/vendor/gtk4-macros-0.9.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408\", \"files\": {}}",
-    "dest": "cargo/vendor/gtk4-macros-0.8.2",
+    "contents": "{\"package\": \"e9e7b362c8fccd2712297903717d65d30defdab2b509bc9d209cbe5ffb9fabaf\", \"files\": {}}",
+    "dest": "cargo/vendor/gtk4-macros-0.9.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.8.2.crate",
-    "sha256": "8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5",
-    "dest": "cargo/vendor/gtk4-sys-0.8.2"
+    "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.9.0.crate",
+    "sha256": "1114a207af8ada02cf4658a76692f4190f06f093380d5be07e3ca8b43aa7c666",
+    "dest": "cargo/vendor/gtk4-sys-0.9.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5\", \"files\": {}}",
-    "dest": "cargo/vendor/gtk4-sys-0.8.2",
+    "contents": "{\"package\": \"1114a207af8ada02cf4658a76692f4190f06f093380d5be07e3ca8b43aa7c666\", \"files\": {}}",
+    "dest": "cargo/vendor/gtk4-sys-0.9.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -938,14 +938,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/indexmap/indexmap-2.2.6.crate",
-    "sha256": "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26",
-    "dest": "cargo/vendor/indexmap-2.2.6"
+    "url": "https://static.crates.io/crates/indexmap/indexmap-2.4.0.crate",
+    "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
+    "dest": "cargo/vendor/indexmap-2.4.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26\", \"files\": {}}",
-    "dest": "cargo/vendor/indexmap-2.2.6",
+    "contents": "{\"package\": \"93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c\", \"files\": {}}",
+    "dest": "cargo/vendor/indexmap-2.4.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -964,14 +964,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.69.crate",
-    "sha256": "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d",
-    "dest": "cargo/vendor/js-sys-0.3.69"
+    "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.70.crate",
+    "sha256": "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a",
+    "dest": "cargo/vendor/js-sys-0.3.70"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d\", \"files\": {}}",
-    "dest": "cargo/vendor/js-sys-0.3.69",
+    "contents": "{\"package\": \"1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a\", \"files\": {}}",
+    "dest": "cargo/vendor/js-sys-0.3.70",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -990,27 +990,27 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/libc/libc-0.2.155.crate",
-    "sha256": "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c",
-    "dest": "cargo/vendor/libc-0.2.155"
+    "url": "https://static.crates.io/crates/libc/libc-0.2.158.crate",
+    "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+    "dest": "cargo/vendor/libc-0.2.158"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c\", \"files\": {}}",
-    "dest": "cargo/vendor/libc-0.2.155",
+    "contents": "{\"package\": \"d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439\", \"files\": {}}",
+    "dest": "cargo/vendor/libc-0.2.158",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/log/log-0.4.21.crate",
-    "sha256": "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c",
-    "dest": "cargo/vendor/log-0.4.21"
+    "url": "https://static.crates.io/crates/log/log-0.4.22.crate",
+    "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+    "dest": "cargo/vendor/log-0.4.22"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c\", \"files\": {}}",
-    "dest": "cargo/vendor/log-0.4.21",
+    "contents": "{\"package\": \"a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24\", \"files\": {}}",
+    "dest": "cargo/vendor/log-0.4.22",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1120,27 +1120,27 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/pango/pango-0.19.8.crate",
-    "sha256": "3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd",
-    "dest": "cargo/vendor/pango-0.19.8"
+    "url": "https://static.crates.io/crates/pango/pango-0.20.1.crate",
+    "sha256": "5764e5a174a5a0ec054fe5962ce6d4fc7052e2d0dcc23bbc77202b40a4a403d3",
+    "dest": "cargo/vendor/pango-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd\", \"files\": {}}",
-    "dest": "cargo/vendor/pango-0.19.8",
+    "contents": "{\"package\": \"5764e5a174a5a0ec054fe5962ce6d4fc7052e2d0dcc23bbc77202b40a4a403d3\", \"files\": {}}",
+    "dest": "cargo/vendor/pango-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.19.8.crate",
-    "sha256": "ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0",
-    "dest": "cargo/vendor/pango-sys-0.19.8"
+    "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.20.1.crate",
+    "sha256": "fd317e1de76b14b3d3efe05518c08b360327f1ab7fec150473a89ffcad4b072d",
+    "dest": "cargo/vendor/pango-sys-0.20.1"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0\", \"files\": {}}",
-    "dest": "cargo/vendor/pango-sys-0.19.8",
+    "contents": "{\"package\": \"fd317e1de76b14b3d3efe05518c08b360327f1ab7fec150473a89ffcad4b072d\", \"files\": {}}",
+    "dest": "cargo/vendor/pango-sys-0.20.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1211,40 +1211,40 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.1.0.crate",
-    "sha256": "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284",
-    "dest": "cargo/vendor/proc-macro-crate-3.1.0"
+    "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.2.0.crate",
+    "sha256": "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b",
+    "dest": "cargo/vendor/proc-macro-crate-3.2.0"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284\", \"files\": {}}",
-    "dest": "cargo/vendor/proc-macro-crate-3.1.0",
+    "contents": "{\"package\": \"8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b\", \"files\": {}}",
+    "dest": "cargo/vendor/proc-macro-crate-3.2.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.85.crate",
-    "sha256": "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23",
-    "dest": "cargo/vendor/proc-macro2-1.0.85"
+    "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.86.crate",
+    "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+    "dest": "cargo/vendor/proc-macro2-1.0.86"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23\", \"files\": {}}",
-    "dest": "cargo/vendor/proc-macro2-1.0.85",
+    "contents": "{\"package\": \"5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77\", \"files\": {}}",
+    "dest": "cargo/vendor/proc-macro2-1.0.86",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/quote/quote-1.0.36.crate",
-    "sha256": "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7",
-    "dest": "cargo/vendor/quote-1.0.36"
+    "url": "https://static.crates.io/crates/quote/quote-1.0.37.crate",
+    "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+    "dest": "cargo/vendor/quote-1.0.37"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7\", \"files\": {}}",
-    "dest": "cargo/vendor/quote-1.0.36",
+    "contents": "{\"package\": \"b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af\", \"files\": {}}",
+    "dest": "cargo/vendor/quote-1.0.37",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1276,40 +1276,53 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/serde/serde-1.0.203.crate",
-    "sha256": "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094",
-    "dest": "cargo/vendor/serde-1.0.203"
+    "url": "https://static.crates.io/crates/serde/serde-1.0.209.crate",
+    "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+    "dest": "cargo/vendor/serde-1.0.209"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094\", \"files\": {}}",
-    "dest": "cargo/vendor/serde-1.0.203",
+    "contents": "{\"package\": \"99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09\", \"files\": {}}",
+    "dest": "cargo/vendor/serde-1.0.209",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.203.crate",
-    "sha256": "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba",
-    "dest": "cargo/vendor/serde_derive-1.0.203"
+    "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.209.crate",
+    "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
+    "dest": "cargo/vendor/serde_derive-1.0.209"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba\", \"files\": {}}",
-    "dest": "cargo/vendor/serde_derive-1.0.203",
+    "contents": "{\"package\": \"a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170\", \"files\": {}}",
+    "dest": "cargo/vendor/serde_derive-1.0.209",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.6.crate",
-    "sha256": "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0",
-    "dest": "cargo/vendor/serde_spanned-0.6.6"
+    "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.7.crate",
+    "sha256": "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d",
+    "dest": "cargo/vendor/serde_spanned-0.6.7"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0\", \"files\": {}}",
-    "dest": "cargo/vendor/serde_spanned-0.6.6",
+    "contents": "{\"package\": \"eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d\", \"files\": {}}",
+    "dest": "cargo/vendor/serde_spanned-0.6.7",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
+    "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+    "dest": "cargo/vendor/shlex-1.3.0"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
+    "dest": "cargo/vendor/shlex-1.3.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1341,118 +1354,105 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/syn/syn-2.0.66.crate",
-    "sha256": "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5",
-    "dest": "cargo/vendor/syn-2.0.66"
+    "url": "https://static.crates.io/crates/syn/syn-2.0.76.crate",
+    "sha256": "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525",
+    "dest": "cargo/vendor/syn-2.0.76"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5\", \"files\": {}}",
-    "dest": "cargo/vendor/syn-2.0.66",
+    "contents": "{\"package\": \"578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525\", \"files\": {}}",
+    "dest": "cargo/vendor/syn-2.0.76",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.2.crate",
-    "sha256": "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349",
-    "dest": "cargo/vendor/system-deps-6.2.2"
+    "url": "https://static.crates.io/crates/system-deps/system-deps-7.0.2.crate",
+    "sha256": "070a0a5e7da2d24be457809c4b3baa57a835fd2829ad8b86f9a049052fe71031",
+    "dest": "cargo/vendor/system-deps-7.0.2"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
-    "dest": "cargo/vendor/system-deps-6.2.2",
+    "contents": "{\"package\": \"070a0a5e7da2d24be457809c4b3baa57a835fd2829ad8b86f9a049052fe71031\", \"files\": {}}",
+    "dest": "cargo/vendor/system-deps-7.0.2",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.14.crate",
-    "sha256": "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f",
-    "dest": "cargo/vendor/target-lexicon-0.12.14"
+    "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+    "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+    "dest": "cargo/vendor/target-lexicon-0.12.16"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f\", \"files\": {}}",
-    "dest": "cargo/vendor/target-lexicon-0.12.14",
+    "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+    "dest": "cargo/vendor/target-lexicon-0.12.16",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.61.crate",
-    "sha256": "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709",
-    "dest": "cargo/vendor/thiserror-1.0.61"
+    "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.63.crate",
+    "sha256": "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724",
+    "dest": "cargo/vendor/thiserror-1.0.63"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709\", \"files\": {}}",
-    "dest": "cargo/vendor/thiserror-1.0.61",
+    "contents": "{\"package\": \"c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724\", \"files\": {}}",
+    "dest": "cargo/vendor/thiserror-1.0.63",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.61.crate",
-    "sha256": "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533",
-    "dest": "cargo/vendor/thiserror-impl-1.0.61"
+    "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.63.crate",
+    "sha256": "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261",
+    "dest": "cargo/vendor/thiserror-impl-1.0.63"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533\", \"files\": {}}",
-    "dest": "cargo/vendor/thiserror-impl-1.0.61",
+    "contents": "{\"package\": \"a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261\", \"files\": {}}",
+    "dest": "cargo/vendor/thiserror-impl-1.0.63",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/toml/toml-0.8.14.crate",
-    "sha256": "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335",
-    "dest": "cargo/vendor/toml-0.8.14"
+    "url": "https://static.crates.io/crates/toml/toml-0.8.19.crate",
+    "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e",
+    "dest": "cargo/vendor/toml-0.8.19"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335\", \"files\": {}}",
-    "dest": "cargo/vendor/toml-0.8.14",
+    "contents": "{\"package\": \"a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e\", \"files\": {}}",
+    "dest": "cargo/vendor/toml-0.8.19",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.6.crate",
-    "sha256": "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf",
-    "dest": "cargo/vendor/toml_datetime-0.6.6"
+    "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.8.crate",
+    "sha256": "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41",
+    "dest": "cargo/vendor/toml_datetime-0.6.8"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf\", \"files\": {}}",
-    "dest": "cargo/vendor/toml_datetime-0.6.6",
+    "contents": "{\"package\": \"0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41\", \"files\": {}}",
+    "dest": "cargo/vendor/toml_datetime-0.6.8",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.21.1.crate",
-    "sha256": "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1",
-    "dest": "cargo/vendor/toml_edit-0.21.1"
+    "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.20.crate",
+    "sha256": "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d",
+    "dest": "cargo/vendor/toml_edit-0.22.20"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1\", \"files\": {}}",
-    "dest": "cargo/vendor/toml_edit-0.21.1",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.14.crate",
-    "sha256": "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38",
-    "dest": "cargo/vendor/toml_edit-0.22.14"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38\", \"files\": {}}",
-    "dest": "cargo/vendor/toml_edit-0.22.14",
+    "contents": "{\"package\": \"583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d\", \"files\": {}}",
+    "dest": "cargo/vendor/toml_edit-0.22.20",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1484,66 +1484,66 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.92.crate",
-    "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
-    "dest": "cargo/vendor/wasm-bindgen-0.2.92"
+    "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.93.crate",
+    "sha256": "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5",
+    "dest": "cargo/vendor/wasm-bindgen-0.2.93"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8\", \"files\": {}}",
-    "dest": "cargo/vendor/wasm-bindgen-0.2.92",
+    "contents": "{\"package\": \"a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5\", \"files\": {}}",
+    "dest": "cargo/vendor/wasm-bindgen-0.2.93",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.92.crate",
-    "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
-    "dest": "cargo/vendor/wasm-bindgen-backend-0.2.92"
+    "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.93.crate",
+    "sha256": "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b",
+    "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da\", \"files\": {}}",
-    "dest": "cargo/vendor/wasm-bindgen-backend-0.2.92",
+    "contents": "{\"package\": \"9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b\", \"files\": {}}",
+    "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.92.crate",
-    "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
-    "dest": "cargo/vendor/wasm-bindgen-macro-0.2.92"
+    "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.93.crate",
+    "sha256": "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf",
+    "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726\", \"files\": {}}",
-    "dest": "cargo/vendor/wasm-bindgen-macro-0.2.92",
+    "contents": "{\"package\": \"585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf\", \"files\": {}}",
+    "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.92.crate",
-    "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
-    "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.92"
+    "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.93.crate",
+    "sha256": "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836",
+    "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7\", \"files\": {}}",
-    "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.92",
+    "contents": "{\"package\": \"afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836\", \"files\": {}}",
+    "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.92.crate",
-    "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
-    "dest": "cargo/vendor/wasm-bindgen-shared-0.2.92"
+    "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.93.crate",
+    "sha256": "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484",
+    "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96\", \"files\": {}}",
-    "dest": "cargo/vendor/wasm-bindgen-shared-0.2.92",
+    "contents": "{\"package\": \"c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484\", \"files\": {}}",
+    "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -1575,144 +1575,131 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.5.crate",
-    "sha256": "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb",
-    "dest": "cargo/vendor/windows-targets-0.52.5"
+    "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+    "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+    "dest": "cargo/vendor/windows-targets-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb\", \"files\": {}}",
-    "dest": "cargo/vendor/windows-targets-0.52.5",
+    "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+    "dest": "cargo/vendor/windows-targets-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.5.crate",
-    "sha256": "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263",
-    "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.5"
+    "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+    "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+    "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.5",
+    "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.5.crate",
-    "sha256": "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6",
-    "dest": "cargo/vendor/windows_aarch64_msvc-0.52.5"
+    "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+    "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+    "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_aarch64_msvc-0.52.5",
+    "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.5.crate",
-    "sha256": "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670",
-    "dest": "cargo/vendor/windows_i686_gnu-0.52.5"
+    "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+    "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+    "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_i686_gnu-0.52.5",
+    "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.5.crate",
-    "sha256": "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9",
-    "dest": "cargo/vendor/windows_i686_gnullvm-0.52.5"
+    "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+    "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+    "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_i686_gnullvm-0.52.5",
+    "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.5.crate",
-    "sha256": "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf",
-    "dest": "cargo/vendor/windows_i686_msvc-0.52.5"
+    "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+    "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+    "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_i686_msvc-0.52.5",
+    "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.5.crate",
-    "sha256": "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9",
-    "dest": "cargo/vendor/windows_x86_64_gnu-0.52.5"
+    "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+    "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+    "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_x86_64_gnu-0.52.5",
+    "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.5.crate",
-    "sha256": "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596",
-    "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.5"
+    "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+    "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+    "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.5",
+    "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.5.crate",
-    "sha256": "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0",
-    "dest": "cargo/vendor/windows_x86_64_msvc-0.52.5"
+    "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+    "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+    "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0\", \"files\": {}}",
-    "dest": "cargo/vendor/windows_x86_64_msvc-0.52.5",
+    "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+    "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
     "dest-filename": ".cargo-checksum.json"
   },
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
-    "sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
-    "dest": "cargo/vendor/winnow-0.5.40"
+    "url": "https://static.crates.io/crates/winnow/winnow-0.6.18.crate",
+    "sha256": "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f",
+    "dest": "cargo/vendor/winnow-0.6.18"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
-    "dest": "cargo/vendor/winnow-0.5.40",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/winnow/winnow-0.6.13.crate",
-    "sha256": "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1",
-    "dest": "cargo/vendor/winnow-0.6.13"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1\", \"files\": {}}",
-    "dest": "cargo/vendor/winnow-0.6.13",
+    "contents": "{\"package\": \"68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f\", \"files\": {}}",
+    "dest": "cargo/vendor/winnow-0.6.18",
     "dest-filename": ".cargo-checksum.json"
   },
   {

--- a/build-aux/modules/gst-plugin-gtk4.json
+++ b/build-aux/modules/gst-plugin-gtk4.json
@@ -4,9 +4,9 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://crates.io/api/v1/crates/gst-plugin-gtk4/0.12.7/download",
-      "dest-filename": "gst-plugin-gtk4-0.12.7.tar.gz",
-      "sha256": "c95543801d561c9fef65704421a7208d06d90dad30f4a5e5e64db741219f6958"
+      "url": "https://crates.io/api/v1/crates/gst-plugin-gtk4/0.13.1/download",
+      "dest-filename": "gst-plugin-gtk4-0.13.1.tar.gz",
+      "sha256": "44b3fe6a92ebf2e62366d9f2d8633cc634187bb7c40fe4db05edfb809e928197"
     },
     "gst-plugin-gtk4-sources.json"
   ],

--- a/build-aux/modules/libportal.json
+++ b/build-aux/modules/libportal.json
@@ -11,8 +11,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz",
-      "sha256": "297b90b263fad22190a26b8c7e8ea938fe6b18fb936265e588927179920d3805"
+      "url": "https://github.com/flatpak/libportal/releases/download/0.8.1/libportal-0.8.1.tar.xz",
+      "sha256": "281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac"
     }
   ]
 }

--- a/build-aux/modules/libportal.json
+++ b/build-aux/modules/libportal.json
@@ -2,6 +2,7 @@
   "name": "libportal",
   "buildsystem": "meson",
   "config-opts": [
+    "--libdir=/app/lib",
     "-Dtests=false",
     "-Dbackend-gtk3=disabled",
     "-Dbackend-gtk4=enabled",

--- a/build-aux/modules/libshumate.json
+++ b/build-aux/modules/libshumate.json
@@ -1,7 +1,7 @@
 {
   "name": "libshumate",
   "buildsystem": "meson",
-  "config-opts": ["-Dgtk_doc=false"],
+  "config-opts": ["--libdir=/app/lib", "-Dgtk_doc=false"],
   "sources": [
     {
       "type": "archive",

--- a/build-aux/modules/libshumate.json
+++ b/build-aux/modules/libshumate.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/libshumate/1.2/libshumate-1.2.2.tar.xz",
-      "sha256": "6f587579f7f2d60b38d3f4727eb1a8d2feac9cbdc018e53ff5f772a8608fa44b"
+      "url": "https://download.gnome.org/sources/libshumate/1.3/libshumate-1.3.0.tar.xz",
+      "sha256": "8227a6e8281cde12232894fef83760d44fa66b39ef033c61ed934a86c6dc75d4"
     }
   ],
   "modules": [

--- a/build-aux/modules/libspelling.json
+++ b/build-aux/modules/libspelling.json
@@ -1,7 +1,7 @@
 {
   "name": "libspelling",
   "buildsystem": "meson",
-  "config-opts": ["-Ddocs=false"],
+  "config-opts": ["--libdir=/app/lib", "-Ddocs=false"],
   "sources": [
     {
       "type": "archive",

--- a/build-aux/modules/libspelling.json
+++ b/build-aux/modules/libspelling.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/libspelling/0.2/libspelling-0.2.1.tar.xz",
-      "sha256": "7a787b467bd493f6baffb44138dbc4bef78aaab60efb76a7db88b243bf0f6343"
+      "url": "https://download.gnome.org/sources/libspelling/0.4/libspelling-0.4.0.tar.xz",
+      "sha256": "00c63970d708a0ef3bcba40e708a06d7030114cb9f210c74583ffad56d36e3dd"
     }
   ]
 }

--- a/build-aux/modules/vte.json
+++ b/build-aux/modules/vte.json
@@ -11,8 +11,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/vte/0.76/vte-0.76.2.tar.xz",
-      "sha256": "e3dc6082d5bd70f8aafaaad2cdfcaf7e51da6ba00a919b11ddac6efa09c72847"
+      "url": "https://download.gnome.org/sources/vte/0.78/vte-0.78.0.tar.xz",
+      "sha256": "07f09c6228a8bb3c1599dd0f5a6ec797b30d3010c3ac91cf21b69d9635dfaf7c"
     }
   ]
 }

--- a/build-aux/modules/vte.json
+++ b/build-aux/modules/vte.json
@@ -2,6 +2,7 @@
   "name": "vte",
   "buildsystem": "meson",
   "config-opts": [
+    "--libdir=/app/lib",
     "-Ddocs=false",
     "-Dgtk3=false",
     "-Dgtk4=true",

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -38,6 +38,7 @@
   ],
   "modules": [
     "modules/blueprint-compiler.json",
+    "modules/biome.json",
     "modules/gst-plugin-gtk4.json",
     "modules/vte.json",
     "modules/libshumate.json",

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -2,17 +2,17 @@
   "$schema": "https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json",
   "id": "re.sonny.Workbench.Devel",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "46",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm18",
-    "org.freedesktop.Sdk.Extension.node18",
+    "org.freedesktop.Sdk.Extension.node20",
     "org.freedesktop.Sdk.Extension.typescript"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin",
+    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin:/usr/lib/sdk/typescript/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib"
   },
   "command": "workbench",

--- a/build-aux/re.sonny.Workbench.Devel.json
+++ b/build-aux/re.sonny.Workbench.Devel.json
@@ -8,11 +8,10 @@
     "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm18",
-    "org.freedesktop.Sdk.Extension.node20",
-    "org.freedesktop.Sdk.Extension.typescript"
+    "org.freedesktop.Sdk.Extension.node20"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin:/usr/lib/sdk/typescript/bin",
+    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib"
   },
   "command": "workbench",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -38,6 +38,7 @@
   ],
   "modules": [
     "modules/blueprint-compiler.json",
+    "modules/biome.json",
     "modules/gst-plugin-gtk4.json",
     "modules/vte.json",
     "modules/libshumate.json",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -8,11 +8,10 @@
     "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm18",
-    "org.freedesktop.Sdk.Extension.node20",
-    "org.freedesktop.Sdk.Extension.typescript"
+    "org.freedesktop.Sdk.Extension.node20"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin:/usr/lib/sdk/typescript/bin",
+    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib"
   },
   "command": "workbench",

--- a/build-aux/re.sonny.Workbench.json
+++ b/build-aux/re.sonny.Workbench.json
@@ -2,17 +2,17 @@
   "$schema": "https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json",
   "id": "re.sonny.Workbench",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "46",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.vala",
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm18",
-    "org.freedesktop.Sdk.Extension.node18",
+    "org.freedesktop.Sdk.Extension.node20",
     "org.freedesktop.Sdk.Extension.typescript"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin",
+    "append-path": "/usr/lib/sdk/vala/bin:/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin:/usr/lib/sdk/typescript/bin",
     "append-ld-library-path": "/usr/lib/sdk/vala/lib"
   },
   "command": "workbench",

--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -88,7 +88,7 @@
         </ul>
         <p>Dependencies:</p>
         <ul>
-          <li>Replace Biome with TypeScript Language Server</li>
+          <li>Update Biome to 1.8.3</li>
           <li>Update gst-plugin-gtk4 to 1.12.7</li>
           <li>Update libshumate to 1.3</li>
           <li>Update Blueprint to 0.14.0</li>

--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -88,7 +88,8 @@
         </ul>
         <p>Dependencies:</p>
         <ul>
-          <li>Update Biome to 1.8.3</li>
+          <!-- <li>Replace Biome with TypeScript Language Server</li> -->
+          <li>Update Biome to 1.9.2</li>
           <li>Update gst-plugin-gtk4 to 1.12.7</li>
           <li>Update libshumate to 1.3</li>
           <li>Update Blueprint to 0.14.0</li>

--- a/data/app.metainfo.xml
+++ b/data/app.metainfo.xml
@@ -43,20 +43,59 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <!-- <release version="47.0" date="2024-xx-xx">
+    <release version="47.0" date="2024-xx-xx">
       <description translatable="no">
         <ul>
-          <li>Library: Add "Button Row" demo</li>
-          <li>Update libshumate to 1.3</li>
+          <li>Use GNOME 47</li>
+          <li>Add code suggestions/completions support</li>
+          <li>Add TypeScript support</li>
+          <li>Add option to create new blank project</li>
         </ul>
-      </description>
-    </release> -->
-
-    <release version="46.2" date="2024-07-xx">
-      <description translatable="no">
+        <p>Library:</p>
+        <ul>
+          <li>Add "Button Row" demo</li>
+          <li>Port "Dialog" to Python</li>
+          <li>Port "Level Bars" to Rust</li>
+          <li>Port "Text Fields" to Rust</li>
+          <li>Port "Column View" to Rust</li>
+          <li>Port "Clamp" to Rust</li>
+          <li>Port "List View" to Rust</li>
+          <li>Port "Frame" to Rust</li>
+          <li>Port "Audio" to Rust</li>
+          <li>Port "File Monitor" to Vala</li>
+          <li>Port "Scrolled Window" to Vala</li>
+          <li>Port "Menu" to Vala</li>
+          <li>Port "HTTP Server" to Vala</li>
+          <li>Port "Map" to Vala</li>
+          <li>Port "Session Monitor and Inhibit" to Vala</li>
+          <li>Port "Save File" to Vala</li>
+          <li>Port "Spin Button" to Vala</li>
+          <li>Port "Progress Bar" to Vala</li>
+          <li>Port "Label" to Vala</li>
+          <li>Port "Power Profile Monitor" to Vala</li>
+          <li>Port "Drawing Area" to Vala</li>
+          <li>Port "Font Dialog" to Vala</li>
+          <li>Port "Select Folder" to Vala</li>
+          <li>Port "Network Monitor" to Vala</li>
+          <li>Port "Toggle Button" to Vala</li>
+          <li>Port "Tooltip" to Vala</li>
+          <li>Port "Spell Checker" to Vala</li>
+          <li>Port "Popovers" to Vala</li>
+          <li>Port "Menu Button" to Vala</li>
+          <li>Port "Frame" to Vala</li>
+          <li>Port "Actions" to Vala</li>
+          <li>Port "Dialog" to Vala</li>
+        </ul>
+        <p>Dependencies:</p>
         <ul>
           <li>Replace Biome with TypeScript Language Server</li>
           <li>Update gst-plugin-gtk4 to 1.12.7</li>
+          <li>Update libshumate to 1.3</li>
+          <li>Update Blueprint to 0.14.0</li>
+          <li>Update vte to 0.78.0</li>
+          <li>Update libspelling to 0.4.0</li>
+          <li>Update libportal to 0.8.1</li>
+          <li>Add GOM dependency 0.5.3</li>
         </ul>
       </description>
     </release>
@@ -150,7 +189,6 @@
           <li>Open the Library on start if there are no sessions to restore</li>
           <li>Restore scroll and cusor positions on format and Run</li>
           <li>Add "Copy" and "Select All" to Console</li>
-          <!-- <li>Add find text support</li> -->
           <li>Add Vala formatter support</li>
           <li>Add WebP image format support</li>
           <li>Use Biome instead of prettier as JavaScript formatter</li>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Workbench', ['vala', 'c', 'rust'],
-  version: '46.2',
+  version: '47.0',
   meson_version: '>= 0.64.0',
   license: 'GPL-3.0-only'
 )

--- a/src/Extensions/Extensions.js
+++ b/src/Extensions/Extensions.js
@@ -77,6 +77,6 @@ export function isTypeScriptEnabled() {
 }
 
 const llvm = "llvm18";
-const node = "node18";
+const node = "node20";
 const runtime = getFlatpakInfo().get_string("Application", "runtime");
-const freedesktop_version = runtime.endsWith("master") ? "24.08beta" : "23.08";
+const freedesktop_version = runtime.endsWith("master") ? "24.08" : "24.08";

--- a/src/application.js
+++ b/src/application.js
@@ -64,7 +64,23 @@ application.connect("open", (_self, files, hint) => {
   load().catch(console.error);
 });
 
+let proc_biome;
+
 application.connect("startup", () => {
+  // biome lsp-proxy starts a background server
+  // it does not get stopped and leaves a process hanging
+  // so manage it manually instead
+  // See https://github.com/workbenchdev/Workbench/issues/828
+  const subprocess_launcher = Gio.SubprocessLauncher.new(
+    Gio.SubprocessFlags.STDERR_SILENCE,
+  );
+  proc_biome = subprocess_launcher.spawnv([
+    "biome",
+    "__run_server",
+    "--config-path",
+    pkg.pkgdatadir,
+  ]);
+
   Library({
     application,
   });
@@ -72,6 +88,10 @@ application.connect("startup", () => {
   ShortcutsWindow({ application });
 
   restoreSessions().catch(console.error);
+});
+
+application.connect("shutdown", () => {
+  proc_biome?.force_exit();
 });
 
 application.connect("activate", () => {

--- a/src/common.js
+++ b/src/common.js
@@ -45,7 +45,13 @@ export const languages = [
     document: null,
     default_file: "main.js",
     index: 0,
-    language_server: ["typescript-language-server", "--stdio"],
+    // language_server: ["typescript-language-server", "--stdio"],
+    language_server: [
+      "biome",
+      "lsp-proxy",
+      // src/meson.build installs biome.json there
+      `--config-path=${pkg.pkgdatadir}`,
+    ],
     formatting_options: {
       ...formatting_options,
       tabSize: 2,

--- a/src/langs/css/CssDocument.js
+++ b/src/langs/css/CssDocument.js
@@ -25,7 +25,7 @@ export class CssDocument extends Document {
       },
     });
 
-    // GTKCssLanguageServer doesn't support diff - it just returns one edit
+    // Biome doesn't support diff - it just returns one edit
     // we don't want to loose the cursor position so we use this
     const state = this.code_view.saveState();
     applyTextEdits(text_edits, this.buffer);

--- a/src/langs/javascript/JavaScriptDocument.js
+++ b/src/langs/javascript/JavaScriptDocument.js
@@ -26,6 +26,10 @@ export class JavaScriptDocument extends Document {
       },
     });
 
+    // Biome doesn't support diff - it just returns one edit
+    // we don't want to loose the cursor position so we use this
+    const state = this.code_view.saveState();
     applyTextEdits(text_edits, this.buffer);
+    await this.code_view.restoreState(state);
   }
 }

--- a/src/langs/javascript/biome.json
+++ b/src/langs/javascript/biome.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.3.3/schema.json",
+  "javascript": {
+    "globals": ["workbench"]
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "noUndeclaredVariables": "error",
+        "noUnusedVariables": "warn"
+      }
+    }
+  }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,7 @@ configure_file(
 )
 
 install_data('langs/vala/workbench.vala', install_dir: pkgdatadir)
+install_data('langs/javascript/biome.json', install_dir: pkgdatadir)
 install_data('project-readme.md', install_dir: pkgdatadir)
 subdir('libworkbench')
 subdir('Previewer')

--- a/src/workbench
+++ b/src/workbench
@@ -8,7 +8,7 @@ export PKG_CONFIG_PATH=/app/lib/pkgconfig/:$PKG_CONFIG_PATH
 source /usr/lib/sdk/rust-stable/enable.sh 2> /dev/null
 source /usr/lib/sdk/vala/enable.sh 2> /dev/null
 source /usr/lib/sdk/llvm18/enable.sh 2> /dev/null
-source /usr/lib/sdk/node18/enable.sh 2> /dev/null
+source /usr/lib/sdk/node20/enable.sh 2> /dev/null
 
 ## enabling the typescript extension
 export PATH=$PATH:/usr/lib/sdk/typescript/bin


### PR DESCRIPTION
Technically depends on https://github.com/flathub/org.freedesktop.Sdk.Extension.typescript/issues/29

Without, TypeScript support is broken.
But I'll merge anyway as keeping separate sdk branches is a mess, and we can move forward and prepare the release.

For now I have re-enabled Biome for JavaScript. 

Hopefully `org.freedesktop.Sdk.Extension.typescript//24.08` will get released soon.