### PR TITLE
fix: HoverProvider `get_iter` crashing

### DIFF
--- a/src/WorkbenchHoverProvider.js
+++ b/src/WorkbenchHoverProvider.js
@@ -12,8 +12,7 @@ class WorkbenchHoverProvider extends GObject.Object {
   }
 
   findDiagnostics(context) {
-    const iter = new Gtk.TextIter();
-    context.get_iter(iter);
+    const [, iter] = context.get_iter();
 
     const line = iter.get_line();
     // Looks like line_offset starts at 0


### PR DESCRIPTION
Ran into this while working on #1002.

Not sure what changed upstream, may need to check documentation.