### PR TITLE
Add llvm21 to PATH

### DIFF
--- a/src/workbench
+++ b/src/workbench
@@ -7,7 +7,7 @@ export PKG_CONFIG_PATH=/app/lib/pkgconfig/:$PKG_CONFIG_PATH
 
 source /usr/lib/sdk/rust-stable/enable.sh 2> /dev/null
 source /usr/lib/sdk/vala/enable.sh 2> /dev/null
-source /usr/lib/sdk/llvm11/enable.sh 2> /dev/null
+source /usr/lib/sdk/llvm21/enable.sh 2> /dev/null
 source /usr/lib/sdk/node24/enable.sh 2> /dev/null
 
 ## enabling the typescript extension


### PR DESCRIPTION
I'm using Workbench in a Flatpak, but it doesn't compile Rust projects, even though I've granted it the network permission via Flatseal and I've added the extensions that Workbench instructed me to:
- org.freedesktop.Sdk.Extension.llvm21
- org.freedesktop.Sdk.Extension.rust-stable

On line 83 of `src/Extensions/Extensions.js`, the version of LLVM used to compile Rust projects is set to `llvm21`. However, the script to actually add the LLVM extension to $PATH tries to add `llvm11` instead.

Until the fix is committed, a user can add the LLVM extension directory to the flatpak's path via an override:
```
  flatpak override --user \
    --env=PATH=/usr/lib/sdk/llvm21/bin:/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
    re.sonny.Workbench
```
