### PR TITLE
Catch deleteSession errors when discarding changes 

### DIFF
--- a/src/sessions.js
+++ b/src/sessions.js
@@ -3,6 +3,7 @@ import GLib from "gi://GLib";
 import Gtk from "gi://Gtk";
 import Gdk from "gi://Gdk";
 
+import { rmrf } from "../troll/src/util.js";
 import {
   data_dir,
   ensureDir,
@@ -11,7 +12,6 @@ import {
   settings as global_settings,
   copyDirectory,
   decode,
-  removeDirectory,
 } from "./util.js";
 import { languages } from "./common.js";
 import { createElement as xml } from "./langs/xml/xml.js";
@@ -90,7 +90,7 @@ export async function createSessionFromDemo(demo) {
 }
 
 export async function deleteSession(session) {
-  return removeDirectory(session.file);
+  return rmrf(session.file);
 }
 
 export async function saveSessionAsProject(session, destination) {

--- a/src/util.js
+++ b/src/util.js
@@ -164,19 +164,6 @@ export function quitOnLastWindowClose(self) {
   return false;
 }
 
-export function removeDirectory(file) {
-  // There is no method to recursively delete a folder so we trash instead
-  // https://github.com/flatpak/xdg-desktop-portal/issues/630 :/
-  // portal.trash_file(file.get_path(), null).catch(console.error);
-  try {
-    file.trash(null);
-  } catch (err) {
-    if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
-      throw err;
-    }
-  }
-}
-
 export async function copy(filename, source_dir, dest_dir, flags) {
   const file = source_dir.get_child(filename);
   const dest_file = dest_dir.get_child(file.get_basename());

--- a/src/window.js
+++ b/src/window.js
@@ -483,7 +483,7 @@ async function onCloseSession({ session, window }) {
   }
 
   if (!session.settings.get_boolean("edited")) {
-    await deleteSession(session);
+    await deleteSession(session).catch(console.error);
     return close(window);
   }
 
@@ -491,7 +491,7 @@ async function onCloseSession({ session, window }) {
   if (response === "cancel") return;
 
   if (response === "discard") {
-    await deleteSession(session);
+    await deleteSession(session).catch(console.error);
   } else if (response === "save") {
     await saveSessionAsProject(session, location);
   }


### PR DESCRIPTION
Fixes #1021 

Happy to adjust the changes as needed, but this "resolves" the error by pushing it to console log. This means the session folder will linger for this specific error, but I believe that should get fix with the next xdg-desktop-portal release (according to the bug ticket.)

Ideally no error should prevent the window from being closed, but this specific error was affecting me and I'd like to close the 10 demo windows I have opened :sweat_smile:. 